### PR TITLE
Add helper funcs for handling args + tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ insert_final_newline = true
 end_of_line = lf
 charset = utf-8
 indent_size = 4
-indent_style = tab
+indent_style = space
 max_line_length = 80
 trim_trailing_whitespace = true
 
@@ -16,7 +16,7 @@ trim_trailing_whitespace = false
 indent_size = 2
 
 
-[Makefile,go.mod,go.sum,*.go]
+[{Makefile,go.mod,go.sum,*.go}]
 indent_style = tab
 tab_width = 4
 max_line_length = 0

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ insert_final_newline = true
 end_of_line = lf
 charset = utf-8
 indent_size = 4
-indent_style = space
+indent_style = tab
 max_line_length = 80
 trim_trailing_whitespace = true
 

--- a/pkg/cli/cmd/subcommand.go
+++ b/pkg/cli/cmd/subcommand.go
@@ -1,177 +1,177 @@
 package cmd
 
 import (
-    "context"
-    "fmt"
+	"context"
+	"fmt"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 // SubCommandRunner is an interface for a subcommand runner
 type SubCommandRunner[T any] interface {
-    // Complete performs any setup or completion of arguments
-    Complete(ctx context.Context, arg T) error
+	// Complete performs any setup or completion of arguments
+	Complete(ctx context.Context, arg T) error
 
-    // Validate checks if the arguments are valid
-    // Returns error if validation fails
-    Validate(ctx context.Context, arg T) error
+	// Validate checks if the arguments are valid
+	// Returns error if validation fails
+	Validate(ctx context.Context, arg T) error
 
-    // Run executes the command with the given arguments
-    // Returns error if execution fails
-    Run(ctx context.Context, arg T) error
+	// Run executes the command with the given arguments
+	// Returns error if execution fails
+	Run(ctx context.Context, arg T) error
 }
 
 // SubCommandBuilder is a builder for a subcommand
 type SubCommandBuilder[T any] struct {
-    cmd       *cobra.Command
-    runner    SubCommandRunner[T]
-    runnerArg T
+	cmd       *cobra.Command
+	runner    SubCommandRunner[T]
+	runnerArg T
 }
 
 // NewSubCommand creates a new subcommand
 // args can be used to pass arguments to the runner
 func NewSubCommand[T any](
-    name string,
-    runner SubCommandRunner[T],
-    runnerArg T,
+	name string,
+	runner SubCommandRunner[T],
+	runnerArg T,
 ) *SubCommandBuilder[T] {
-    c := &cobra.Command{
-        Use: name,
-    }
+	c := &cobra.Command{
+		Use: name,
+	}
 
-    return &SubCommandBuilder[T]{
-        cmd:       c,
-        runner:    runner,
-        runnerArg: runnerArg,
-    }
+	return &SubCommandBuilder[T]{
+		cmd:       c,
+		runner:    runner,
+		runnerArg: runnerArg,
+	}
 }
 
 // WithShortDesc sets the short description of the subcommand
 func (b *SubCommandBuilder[T]) WithShortDesc(desc string) *SubCommandBuilder[T] {
-    b.cmd.Short = desc
-    return b
+	b.cmd.Short = desc
+	return b
 }
 
 // WithLongDesc sets the long description of the subcommand
 func (b *SubCommandBuilder[T]) WithLongDesc(desc string) *SubCommandBuilder[T] {
-    b.cmd.Long = desc
-    return b
+	b.cmd.Long = desc
+	return b
 }
 
 // WithGroupID sets the group id of the subcommand
 func (b *SubCommandBuilder[T]) WithGroupID(group string) *SubCommandBuilder[T] {
-    b.cmd.GroupID = group
-    return b
+	b.cmd.GroupID = group
+	return b
 }
 
 // WithExample sets the example of the subcommand
 func (b *SubCommandBuilder[T]) WithExample(example string) *SubCommandBuilder[T] {
-    b.cmd.Example = example
-    return b
+	b.cmd.Example = example
+	return b
 }
 
 // Build builds the subcommand
 func (b *SubCommandBuilder[T]) Build() *cobra.Command {
-    b.cmd.RunE = mkRunE(b.runner, b.runnerArg)
-    return b.cmd
+	b.cmd.RunE = mkRunE(b.runner, b.runnerArg)
+	return b.cmd
 }
 
 // WithNoArgs causes the subcommand to return an error if any arguments are passed
 func (b *SubCommandBuilder[T]) WithNoArgs() *SubCommandBuilder[T] {
-    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
-        if len(args) > 0 {
-            return fmt.Errorf(
-                "%q does not accept any arguments\n\nUsage: %s",
-                cmd.CommandPath(),
-                cmd.UseLine(),
-            )
-        }
-        return nil
-    }
-    return b
+	b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return fmt.Errorf(
+				"%q does not accept any arguments\n\nUsage: %s",
+				cmd.CommandPath(),
+				cmd.UseLine(),
+			)
+		}
+		return nil
+	}
+	return b
 }
 
 // WithExactArgs causes the subcommand to return an error if there are not exactly n arguments
 func (b *SubCommandBuilder[T]) WithExactArgs(n int) *SubCommandBuilder[T] {
-    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
-        if len(args) != n {
-            return fmt.Errorf(
-                "%q requires exactly %d arguments\n\nUsage: %s",
-                cmd.CommandPath(),
-                n,
-                cmd.UseLine(),
-            )
-        }
-        return nil
-    }
-    return b
+	b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf(
+				"%q requires exactly %d arguments\n\nUsage: %s",
+				cmd.CommandPath(),
+				n,
+				cmd.UseLine(),
+			)
+		}
+		return nil
+	}
+	return b
 }
 
 // WithMinArgs causes the subcommand to return an error if there is not at least n arguments
 func (b *SubCommandBuilder[T]) WithMinArgs(n int) *SubCommandBuilder[T] {
-    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
-        if len(args) < n {
-            return fmt.Errorf(
-                "%q requires at least %d arguments\n\nUsage: %s",
-                cmd.CommandPath(),
-                n,
-                cmd.UseLine(),
-            )
-        }
-        return nil
-    }
-    return b
+	b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+		if len(args) < n {
+			return fmt.Errorf(
+				"%q requires at least %d arguments\n\nUsage: %s",
+				cmd.CommandPath(),
+				n,
+				cmd.UseLine(),
+			)
+		}
+		return nil
+	}
+	return b
 }
 
 // WithMaxArgs causes the subcommand to return an error if there are more than n arguments
 func (b *SubCommandBuilder[T]) WithMaxArgs(n int) *SubCommandBuilder[T] {
-    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
-        if len(args) > n {
-            return fmt.Errorf(
-                "%q accepts at most %d arguments\n\nUsage: %s",
-                cmd.CommandPath(),
-                n,
-                cmd.UseLine(),
-            )
-        }
-        return nil
-    }
-    return b
+	b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+		if len(args) > n {
+			return fmt.Errorf(
+				"%q accepts at most %d arguments\n\nUsage: %s",
+				cmd.CommandPath(),
+				n,
+				cmd.UseLine(),
+			)
+		}
+		return nil
+	}
+	return b
 }
 
 // mkRunE creates a RunE function for a subcommand
 // runnerArgs are passed to the runner.Complete, runner.Validate and runner.Run methods
 // it is up to the runner to decide how to use these arguments
 func mkRunE[T any](runner SubCommandRunner[T], runnerArg T) func(*cobra.Command, []string) error {
-    return func(cmd *cobra.Command, args []string) error {
-        ctx := cmd.Context()
-        if err := runner.Complete(ctx, runnerArg); err != nil {
-            return err
-        }
-        if err := runner.Validate(ctx, runnerArg); err != nil {
-            return err
-        }
-        return runner.Run(ctx, runnerArg)
-    }
+	return func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if err := runner.Complete(ctx, runnerArg); err != nil {
+			return err
+		}
+		if err := runner.Validate(ctx, runnerArg); err != nil {
+			return err
+		}
+		return runner.Run(ctx, runnerArg)
+	}
 }
 
 // TestRunner is a test runner for commands
 type TestRunner[T any] struct {
-    CompleteFunc func(T) error
-    ValidateFunc func(T) error
-    RunFunc      func(T) error
+	CompleteFunc func(T) error
+	ValidateFunc func(T) error
+	RunFunc      func(T) error
 }
 
 func (tr *TestRunner[T]) Complete(ctx context.Context, runnerArg T) error {
-    return tr.CompleteFunc(runnerArg)
+	return tr.CompleteFunc(runnerArg)
 }
 
 func (tr *TestRunner[T]) Validate(ctx context.Context, runnerArg T) error {
-    return tr.ValidateFunc(runnerArg)
+	return tr.ValidateFunc(runnerArg)
 }
 
 func (tr *TestRunner[T]) Run(ctx context.Context, runnerArg T) error {
-    return tr.RunFunc(runnerArg)
+	return tr.RunFunc(runnerArg)
 }
 
 type NoopRunner[T any] struct{}

--- a/pkg/cli/cmd/subcommand.go
+++ b/pkg/cli/cmd/subcommand.go
@@ -1,119 +1,177 @@
 package cmd
 
 import (
-	"context"
+    "context"
+    "fmt"
 
-	"github.com/spf13/cobra"
+    "github.com/spf13/cobra"
 )
 
 // SubCommandRunner is an interface for a subcommand runner
 type SubCommandRunner[T any] interface {
-	// Complete performs any setup or completion of arguments
-	Complete(ctx context.Context, arg T) error
+    // Complete performs any setup or completion of arguments
+    Complete(ctx context.Context, arg T) error
 
-	// Validate checks if the arguments are valid
-	// Returns error if validation fails
-	Validate(ctx context.Context, arg T) error
+    // Validate checks if the arguments are valid
+    // Returns error if validation fails
+    Validate(ctx context.Context, arg T) error
 
-	// Run executes the command with the given arguments
-	// Returns error if execution fails
-	Run(ctx context.Context, arg T) error
+    // Run executes the command with the given arguments
+    // Returns error if execution fails
+    Run(ctx context.Context, arg T) error
 }
 
 // SubCommandBuilder is a builder for a subcommand
 type SubCommandBuilder[T any] struct {
-	cmd       *cobra.Command
-	runner    SubCommandRunner[T]
-	runnerArg T
+    cmd       *cobra.Command
+    runner    SubCommandRunner[T]
+    runnerArg T
 }
 
 // NewSubCommand creates a new subcommand
 // args can be used to pass arguments to the runner
 func NewSubCommand[T any](
-	name string,
-	runner SubCommandRunner[T],
-	runnerArg T,
+    name string,
+    runner SubCommandRunner[T],
+    runnerArg T,
 ) *SubCommandBuilder[T] {
-	c := &cobra.Command{
-		Use: name,
-	}
+    c := &cobra.Command{
+        Use: name,
+    }
 
-	return &SubCommandBuilder[T]{
-		cmd:       c,
-		runner:    runner,
-		runnerArg: runnerArg,
-	}
+    return &SubCommandBuilder[T]{
+        cmd:       c,
+        runner:    runner,
+        runnerArg: runnerArg,
+    }
 }
 
 // WithShortDesc sets the short description of the subcommand
 func (b *SubCommandBuilder[T]) WithShortDesc(desc string) *SubCommandBuilder[T] {
-	b.cmd.Short = desc
-	return b
+    b.cmd.Short = desc
+    return b
 }
 
 // WithLongDesc sets the long description of the subcommand
 func (b *SubCommandBuilder[T]) WithLongDesc(desc string) *SubCommandBuilder[T] {
-	b.cmd.Long = desc
-	return b
+    b.cmd.Long = desc
+    return b
 }
 
 // WithGroupID sets the group id of the subcommand
 func (b *SubCommandBuilder[T]) WithGroupID(group string) *SubCommandBuilder[T] {
-	b.cmd.GroupID = group
-	return b
+    b.cmd.GroupID = group
+    return b
 }
 
 // WithExample sets the example of the subcommand
 func (b *SubCommandBuilder[T]) WithExample(example string) *SubCommandBuilder[T] {
-	b.cmd.Example = example
-	return b
+    b.cmd.Example = example
+    return b
 }
 
 // Build builds the subcommand
 func (b *SubCommandBuilder[T]) Build() *cobra.Command {
-	b.cmd.RunE = mkRunE(b.runner, b.runnerArg)
-	return b.cmd
+    b.cmd.RunE = mkRunE(b.runner, b.runnerArg)
+    return b.cmd
 }
 
-// WithExample sets the example of the subcommand
+// WithNoArgs causes the subcommand to return an error if any arguments are passed
 func (b *SubCommandBuilder[T]) WithNoArgs() *SubCommandBuilder[T] {
-	b.cmd.Args = cobra.NoArgs
-	return b
+    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+        if len(args) > 0 {
+            return fmt.Errorf(
+                "%q does not accept any arguments\n\nUsage: %s",
+                cmd.CommandPath(),
+                cmd.UseLine(),
+            )
+        }
+        return nil
+    }
+    return b
+}
+
+// WithExactArgs causes the subcommand to return an error if there are not exactly n arguments
+func (b *SubCommandBuilder[T]) WithExactArgs(n int) *SubCommandBuilder[T] {
+    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+        if len(args) != n {
+            return fmt.Errorf(
+                "%q requires exactly %d arguments\n\nUsage: %s",
+                cmd.CommandPath(),
+                n,
+                cmd.UseLine(),
+            )
+        }
+        return nil
+    }
+    return b
+}
+
+// WithMinArgs causes the subcommand to return an error if there is not at least n arguments
+func (b *SubCommandBuilder[T]) WithMinArgs(n int) *SubCommandBuilder[T] {
+    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+        if len(args) < n {
+            return fmt.Errorf(
+                "%q requires at least %d arguments\n\nUsage: %s",
+                cmd.CommandPath(),
+                n,
+                cmd.UseLine(),
+            )
+        }
+        return nil
+    }
+    return b
+}
+
+// WithMaxArgs causes the subcommand to return an error if there are more than n arguments
+func (b *SubCommandBuilder[T]) WithMaxArgs(n int) *SubCommandBuilder[T] {
+    b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+        if len(args) > n {
+            return fmt.Errorf(
+                "%q accepts at most %d arguments\n\nUsage: %s",
+                cmd.CommandPath(),
+                n,
+                cmd.UseLine(),
+            )
+        }
+        return nil
+    }
+    return b
 }
 
 // mkRunE creates a RunE function for a subcommand
 // runnerArgs are passed to the runner.Complete, runner.Validate and runner.Run methods
 // it is up to the runner to decide how to use these arguments
 func mkRunE[T any](runner SubCommandRunner[T], runnerArg T) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		if err := runner.Complete(ctx, runnerArg); err != nil {
-			return err
-		}
-		if err := runner.Validate(ctx, runnerArg); err != nil {
-			return err
-		}
-		return runner.Run(ctx, runnerArg)
-	}
+    return func(cmd *cobra.Command, args []string) error {
+        ctx := cmd.Context()
+        if err := runner.Complete(ctx, runnerArg); err != nil {
+            return err
+        }
+        if err := runner.Validate(ctx, runnerArg); err != nil {
+            return err
+        }
+        return runner.Run(ctx, runnerArg)
+    }
 }
 
 // TestRunner is a test runner for commands
 type TestRunner[T any] struct {
-	CompleteFunc func(T) error
-	ValidateFunc func(T) error
-	RunFunc      func(T) error
+    CompleteFunc func(T) error
+    ValidateFunc func(T) error
+    RunFunc      func(T) error
 }
 
 func (tr *TestRunner[T]) Complete(ctx context.Context, runnerArg T) error {
-	return tr.CompleteFunc(runnerArg)
+    return tr.CompleteFunc(runnerArg)
 }
 
 func (tr *TestRunner[T]) Validate(ctx context.Context, runnerArg T) error {
-	return tr.ValidateFunc(runnerArg)
+    return tr.ValidateFunc(runnerArg)
 }
 
 func (tr *TestRunner[T]) Run(ctx context.Context, runnerArg T) error {
-	return tr.RunFunc(runnerArg)
+    return tr.RunFunc(runnerArg)
 }
 
 type NoopRunner[T any] struct{}

--- a/pkg/cli/cmd/subcommand_test.go
+++ b/pkg/cli/cmd/subcommand_test.go
@@ -1,158 +1,158 @@
 package cmd
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/spf13/cobra"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSubCommand(t *testing.T) {
-    runner := &NoopRunner[any]{}
-    cmd := NewSubCommand("test", runner, nil)
-    require.NotNil(t, cmd)
-    assert.Equal(t, "test", cmd.cmd.Use)
-    assert.Nil(t, cmd.cmd.RunE)
+	runner := &NoopRunner[any]{}
+	cmd := NewSubCommand("test", runner, nil)
+	require.NotNil(t, cmd)
+	assert.Equal(t, "test", cmd.cmd.Use)
+	assert.Nil(t, cmd.cmd.RunE)
 }
 
 func TestSubCommandBuilderMethods(t *testing.T) {
-    runner := &NoopRunner[any]{}
-    builder := NewSubCommand("test", runner, nil)
+	runner := &NoopRunner[any]{}
+	builder := NewSubCommand("test", runner, nil)
 
-    builder.WithShortDesc("short description")
-    builder.WithLongDesc("long description")
-    builder.WithGroupID("group ID")
-    builder.WithExample("example usage")
-    builder.WithNoArgs()
-    cmd := builder.Build()
+	builder.WithShortDesc("short description")
+	builder.WithLongDesc("long description")
+	builder.WithGroupID("group ID")
+	builder.WithExample("example usage")
+	builder.WithNoArgs()
+	cmd := builder.Build()
 
-    assert.Equal(t, "short description", cmd.Short)
-    assert.Equal(t, "long description", cmd.Long)
-    assert.Equal(t, "group ID", cmd.GroupID)
-    assert.Equal(t, "example usage", cmd.Example)
-    assert.NotNil(t, cmd.Args)
-    assert.NotNil(t, cmd.RunE)
+	assert.Equal(t, "short description", cmd.Short)
+	assert.Equal(t, "long description", cmd.Long)
+	assert.Equal(t, "group ID", cmd.GroupID)
+	assert.Equal(t, "example usage", cmd.Example)
+	assert.NotNil(t, cmd.Args)
+	assert.NotNil(t, cmd.RunE)
 }
 
 func Test_mkRunE(t *testing.T) {
-    type arg struct{}
+	type arg struct{}
 
-    t.Run("complete_called", func(t *testing.T) {
-        completeCalled := false
-        runner := &TestRunner[arg]{
-            CompleteFunc: func(a arg) error {
-                completeCalled = true
-                return nil
-            },
-            ValidateFunc: func(a arg) error { return nil },
-            RunFunc:      func(a arg) error { return nil },
-        }
-        runE := mkRunE(runner, arg{})
-        cmd := &cobra.Command{}
-        err := runE(cmd, []string{})
-        assert.Nil(t, err)
-        assert.True(t, completeCalled)
-    })
+	t.Run("complete_called", func(t *testing.T) {
+		completeCalled := false
+		runner := &TestRunner[arg]{
+			CompleteFunc: func(a arg) error {
+				completeCalled = true
+				return nil
+			},
+			ValidateFunc: func(a arg) error { return nil },
+			RunFunc:      func(a arg) error { return nil },
+		}
+		runE := mkRunE(runner, arg{})
+		cmd := &cobra.Command{}
+		err := runE(cmd, []string{})
+		assert.Nil(t, err)
+		assert.True(t, completeCalled)
+	})
 
-    t.Run("validate_error", func(t *testing.T) {
-        runner := &TestRunner[arg]{
-            CompleteFunc: func(a arg) error { return nil },
-            ValidateFunc: func(a arg) error { return assert.AnError },
-            RunFunc:      func(a arg) error { return nil },
-        }
-        runE := mkRunE(runner, arg{})
-        cmd := &cobra.Command{}
-        err := runE(cmd, []string{})
-        assert.Error(t, err)
-    })
+	t.Run("validate_error", func(t *testing.T) {
+		runner := &TestRunner[arg]{
+			CompleteFunc: func(a arg) error { return nil },
+			ValidateFunc: func(a arg) error { return assert.AnError },
+			RunFunc:      func(a arg) error { return nil },
+		}
+		runE := mkRunE(runner, arg{})
+		cmd := &cobra.Command{}
+		err := runE(cmd, []string{})
+		assert.Error(t, err)
+	})
 
-    t.Run("run_called", func(t *testing.T) {
-        runCalled := false
-        runner := &TestRunner[arg]{
-            CompleteFunc: func(a arg) error { return nil },
-            ValidateFunc: func(a arg) error { return nil },
-            RunFunc:      func(a arg) error { runCalled = true; return nil },
-        }
+	t.Run("run_called", func(t *testing.T) {
+		runCalled := false
+		runner := &TestRunner[arg]{
+			CompleteFunc: func(a arg) error { return nil },
+			ValidateFunc: func(a arg) error { return nil },
+			RunFunc:      func(a arg) error { runCalled = true; return nil },
+		}
 
-        runE := mkRunE(runner, arg{})
-        cmd := &cobra.Command{}
-        err := runE(cmd, []string{})
-        assert.Nil(t, err)
-        assert.True(t, runCalled)
-    })
+		runE := mkRunE(runner, arg{})
+		cmd := &cobra.Command{}
+		err := runE(cmd, []string{})
+		assert.Nil(t, err)
+		assert.True(t, runCalled)
+	})
 }
 
 func TestArgsHelpers(t *testing.T) {
-    t.Run("NoArgsReturnsErrorWhenArgsProvided", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithNoArgs()
-        cmd := builder.Build()
+	t.Run("NoArgsReturnsErrorWhenArgsProvided", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithNoArgs()
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1"})
-        assert.Error(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1"})
+		assert.Error(t, err)
+	})
 
-    t.Run("NoArgsSucceedsWhenNoArgsProvided", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithNoArgs()
-        cmd := builder.Build()
+	t.Run("NoArgsSucceedsWhenNoArgsProvided", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithNoArgs()
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{})
-        assert.NoError(t, err)
-    })
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+	})
 
-    t.Run("ExactArgsReturnsErrorWhenArgsCountMismatch", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithExactArgs(2)
-        cmd := builder.Build()
+	t.Run("ExactArgsReturnsErrorWhenArgsCountMismatch", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithExactArgs(2)
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1"})
-        assert.Error(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1"})
+		assert.Error(t, err)
+	})
 
-    t.Run("ExactArgsSucceedsWhenArgsCountMatches", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithExactArgs(2)
-        cmd := builder.Build()
+	t.Run("ExactArgsSucceedsWhenArgsCountMatches", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithExactArgs(2)
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1", "arg2"})
-        assert.NoError(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1", "arg2"})
+		assert.NoError(t, err)
+	})
 
-    t.Run("MinArgsReturnsErrorWhenArgsCountLessThanMin", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithMinArgs(2)
-        cmd := builder.Build()
+	t.Run("MinArgsReturnsErrorWhenArgsCountLessThanMin", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithMinArgs(2)
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1"})
-        assert.Error(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1"})
+		assert.Error(t, err)
+	})
 
-    t.Run("MinArgsSucceedsWhenArgsCountAtLeastMin", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithMinArgs(2)
-        cmd := builder.Build()
+	t.Run("MinArgsSucceedsWhenArgsCountAtLeastMin", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithMinArgs(2)
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1", "arg2"})
-        assert.NoError(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1", "arg2"})
+		assert.NoError(t, err)
+	})
 
-    t.Run("MaxArgsReturnsErrorWhenArgsCountMoreThanMax", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithMaxArgs(2)
-        cmd := builder.Build()
+	t.Run("MaxArgsReturnsErrorWhenArgsCountMoreThanMax", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithMaxArgs(2)
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1", "arg2", "arg3"})
-        assert.Error(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1", "arg2", "arg3"})
+		assert.Error(t, err)
+	})
 
-    t.Run("MaxArgsSucceedsWhenArgsCountAtMostMax", func(t *testing.T) {
-        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
-        builder.WithMaxArgs(2)
-        cmd := builder.Build()
+	t.Run("MaxArgsSucceedsWhenArgsCountAtMostMax", func(t *testing.T) {
+		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+		builder.WithMaxArgs(2)
+		cmd := builder.Build()
 
-        err := cmd.Args(cmd, []string{"arg1", "arg2"})
-        assert.NoError(t, err)
-    })
+		err := cmd.Args(cmd, []string{"arg1", "arg2"})
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/cli/cmd/subcommand_test.go
+++ b/pkg/cli/cmd/subcommand_test.go
@@ -1,84 +1,158 @@
 package cmd
 
 import (
-	"testing"
+    "testing"
 
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+    "github.com/spf13/cobra"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
 )
 
 func TestNewSubCommand(t *testing.T) {
-	runner := &NoopRunner[any]{}
-	cmd := NewSubCommand("test", runner, nil)
-	require.NotNil(t, cmd)
-	assert.Equal(t, "test", cmd.cmd.Use)
-	assert.Nil(t, cmd.cmd.RunE)
+    runner := &NoopRunner[any]{}
+    cmd := NewSubCommand("test", runner, nil)
+    require.NotNil(t, cmd)
+    assert.Equal(t, "test", cmd.cmd.Use)
+    assert.Nil(t, cmd.cmd.RunE)
 }
 
 func TestSubCommandBuilderMethods(t *testing.T) {
-	runner := &NoopRunner[any]{}
-	builder := NewSubCommand("test", runner, nil)
+    runner := &NoopRunner[any]{}
+    builder := NewSubCommand("test", runner, nil)
 
-	builder.WithShortDesc("short description")
-	builder.WithLongDesc("long description")
-	builder.WithGroupID("group ID")
-	builder.WithExample("example usage")
-	builder.WithNoArgs()
-	cmd := builder.Build()
+    builder.WithShortDesc("short description")
+    builder.WithLongDesc("long description")
+    builder.WithGroupID("group ID")
+    builder.WithExample("example usage")
+    builder.WithNoArgs()
+    cmd := builder.Build()
 
-	assert.Equal(t, "short description", cmd.Short)
-	assert.Equal(t, "long description", cmd.Long)
-	assert.Equal(t, "group ID", cmd.GroupID)
-	assert.Equal(t, "example usage", cmd.Example)
-	assert.NotNil(t, cmd.Args)
-	assert.NotNil(t, cmd.RunE)
+    assert.Equal(t, "short description", cmd.Short)
+    assert.Equal(t, "long description", cmd.Long)
+    assert.Equal(t, "group ID", cmd.GroupID)
+    assert.Equal(t, "example usage", cmd.Example)
+    assert.NotNil(t, cmd.Args)
+    assert.NotNil(t, cmd.RunE)
 }
 
 func Test_mkRunE(t *testing.T) {
-	type arg struct{}
+    type arg struct{}
 
-	t.Run("complete_called", func(t *testing.T) {
-		completeCalled := false
-		runner := &TestRunner[arg]{
-			CompleteFunc: func(a arg) error {
-				completeCalled = true
-				return nil
-			},
-			ValidateFunc: func(a arg) error { return nil },
-			RunFunc:      func(a arg) error { return nil },
-		}
-		runE := mkRunE(runner, arg{})
-		cmd := &cobra.Command{}
-		err := runE(cmd, []string{})
-		assert.Nil(t, err)
-		assert.True(t, completeCalled)
-	})
+    t.Run("complete_called", func(t *testing.T) {
+        completeCalled := false
+        runner := &TestRunner[arg]{
+            CompleteFunc: func(a arg) error {
+                completeCalled = true
+                return nil
+            },
+            ValidateFunc: func(a arg) error { return nil },
+            RunFunc:      func(a arg) error { return nil },
+        }
+        runE := mkRunE(runner, arg{})
+        cmd := &cobra.Command{}
+        err := runE(cmd, []string{})
+        assert.Nil(t, err)
+        assert.True(t, completeCalled)
+    })
 
-	t.Run("validate_error", func(t *testing.T) {
-		runner := &TestRunner[arg]{
-			CompleteFunc: func(a arg) error { return nil },
-			ValidateFunc: func(a arg) error { return assert.AnError },
-			RunFunc:      func(a arg) error { return nil },
-		}
-		runE := mkRunE(runner, arg{})
-		cmd := &cobra.Command{}
-		err := runE(cmd, []string{})
-		assert.Error(t, err)
-	})
+    t.Run("validate_error", func(t *testing.T) {
+        runner := &TestRunner[arg]{
+            CompleteFunc: func(a arg) error { return nil },
+            ValidateFunc: func(a arg) error { return assert.AnError },
+            RunFunc:      func(a arg) error { return nil },
+        }
+        runE := mkRunE(runner, arg{})
+        cmd := &cobra.Command{}
+        err := runE(cmd, []string{})
+        assert.Error(t, err)
+    })
 
-	t.Run("run_called", func(t *testing.T) {
-		runCalled := false
-		runner := &TestRunner[arg]{
-			CompleteFunc: func(a arg) error { return nil },
-			ValidateFunc: func(a arg) error { return nil },
-			RunFunc:      func(a arg) error { runCalled = true; return nil },
-		}
+    t.Run("run_called", func(t *testing.T) {
+        runCalled := false
+        runner := &TestRunner[arg]{
+            CompleteFunc: func(a arg) error { return nil },
+            ValidateFunc: func(a arg) error { return nil },
+            RunFunc:      func(a arg) error { runCalled = true; return nil },
+        }
 
-		runE := mkRunE(runner, arg{})
-		cmd := &cobra.Command{}
-		err := runE(cmd, []string{})
-		assert.Nil(t, err)
-		assert.True(t, runCalled)
-	})
+        runE := mkRunE(runner, arg{})
+        cmd := &cobra.Command{}
+        err := runE(cmd, []string{})
+        assert.Nil(t, err)
+        assert.True(t, runCalled)
+    })
+}
+
+func TestArgsHelpers(t *testing.T) {
+    t.Run("NoArgsReturnsErrorWhenArgsProvided", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithNoArgs()
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1"})
+        assert.Error(t, err)
+    })
+
+    t.Run("NoArgsSucceedsWhenNoArgsProvided", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithNoArgs()
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{})
+        assert.NoError(t, err)
+    })
+
+    t.Run("ExactArgsReturnsErrorWhenArgsCountMismatch", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithExactArgs(2)
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1"})
+        assert.Error(t, err)
+    })
+
+    t.Run("ExactArgsSucceedsWhenArgsCountMatches", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithExactArgs(2)
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1", "arg2"})
+        assert.NoError(t, err)
+    })
+
+    t.Run("MinArgsReturnsErrorWhenArgsCountLessThanMin", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithMinArgs(2)
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1"})
+        assert.Error(t, err)
+    })
+
+    t.Run("MinArgsSucceedsWhenArgsCountAtLeastMin", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithMinArgs(2)
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1", "arg2"})
+        assert.NoError(t, err)
+    })
+
+    t.Run("MaxArgsReturnsErrorWhenArgsCountMoreThanMax", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithMaxArgs(2)
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1", "arg2", "arg3"})
+        assert.Error(t, err)
+    })
+
+    t.Run("MaxArgsSucceedsWhenArgsCountAtMostMax", func(t *testing.T) {
+        builder := NewSubCommand("test", &NoopRunner[any]{}, nil)
+        builder.WithMaxArgs(2)
+        cmd := builder.Build()
+
+        err := cmd.Args(cmd, []string{"arg1", "arg2"})
+        assert.NoError(t, err)
+    })
 }


### PR DESCRIPTION
I am aware that we could use the args helper funcs provided by Cobra, but i do not think the error message is the best for those. 