### PR TITLE
enable showCaller when log level is debug

### DIFF
--- a/pkg/cli/cmd/context.go
+++ b/pkg/cli/cmd/context.go
@@ -94,6 +94,9 @@ func NewExecutionContext(appName, shortDesc, version string) *ExecutionContext {
 // SetLogLevel sets the ec.Logger log level
 func (ec *ExecutionContext) SetLogLevel() {
 	ui.Logger.Level = ui.ParseLevel(ec.PFlags.LogLevel.String())
+	if ui.Logger.Level == ui.ParseLevel(string(LogLevelDebug)) {
+		ui.Logger.ShowCaller = true
+	}
 	ec.LogLevel.Set(ParseLogLevel(ec.PFlags.LogLevel))
 }
 

--- a/pkg/cli/cmd/context.go
+++ b/pkg/cli/cmd/context.go
@@ -93,11 +93,14 @@ func NewExecutionContext(appName, shortDesc, version string) *ExecutionContext {
 
 // SetLogLevel sets the ec.Logger log level
 func (ec *ExecutionContext) SetLogLevel() {
-	ui.Logger.Level = ui.ParseLevel(ec.PFlags.LogLevel.String())
-	if ui.Logger.Level == ui.ParseLevel(string(LogLevelDebug)) {
-		ui.Logger.ShowCaller = true
+	logLevel := ec.PFlags.LogLevel
+	if ec.PFlags.Debug {
+		logLevel = LogLevelDebug
 	}
-	ec.LogLevel.Set(ParseLogLevel(ec.PFlags.LogLevel))
+	ui.Logger.Level = ui.ParseLevel(logLevel.String())
+	ec.LogLevel.Set(ParseLogLevel(logLevel))
+
+	ui.Logger.ShowCaller = ec.PFlags.Debug || ui.Logger.Level == ui.ParseLevel(LogLevelDebug.String())
 }
 
 // SetColor sets weather color should be used in the output


### PR DESCRIPTION
This pull request includes a small change to the `pkg/cli/cmd/context.go` file. The change ensures that when the log level is set to `LogLevelDebug`, the logger will also display the caller information.

* [`pkg/cli/cmd/context.go`](diffhunk://#diff-5f82f1b1c3c0cc0dc196b58c8ebdb98de591fbd2ab83e46ddce57b0902c564a4R97-R99): Added logic to set `ShowCaller` to `true` when the log level is `LogLevelDebug`.