### PR TITLE
feat: add pkg/cli/secrets package to add secrets to flags in a secure way

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/go-github/v69 v69.2.0
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-shellwords v1.0.12
 	github.com/migueleliasweb/go-github-mock v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/prometheus/client_golang v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -944,8 +944,8 @@ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+m
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=
 github.com/edsrzf/mmap-go v1.2.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
-github.com/elazarl/goproxy v1.4.0 h1:4GyuSbFa+s26+3rmYNSuUVsx+HgPrV1bk1jXI0l9wjM=
-github.com/elazarl/goproxy v1.4.0/go.mod h1:X/5W/t+gzDyLfHW4DrMdpjqYjpXsURlBt9lpBDxZZZQ=
+github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
+github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/elliotchance/phpserialize v1.4.0 h1:cAp/9+KSnEbUC8oYCE32n2n84BeW8HOY3HMDI8hG2OY=
 github.com/elliotchance/phpserialize v1.4.0/go.mod h1:gt7XX9+ETUcLXbtTKEuyrqW3lcLUAeS/AnGZ2e49TZs=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
@@ -1033,8 +1033,6 @@ github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UN
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.13.2 h1:7O7xvsK7K+rZPKW6AQR1YyNhfywkv7B8/FsP3ki6Zv0=
-github.com/go-git/go-git/v5 v5.13.2/go.mod h1:hWdW5P4YZRjmpGHwRH2v3zkWcNl6HeXaXQEMGb3NJ9A=
 github.com/go-git/go-git/v5 v5.14.0 h1:/MD3lCrGjCen5WfEAzKg00MJJffKhC8gzS80ycmCi60=
 github.com/go-git/go-git/v5 v5.14.0/go.mod h1:Z5Xhoia5PcWA3NF8vRLURn9E5FRhSl7dGj9ItW3Wk5k=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -1151,7 +1149,6 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -1447,6 +1444,8 @@ github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRC
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
@@ -1639,8 +1638,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rubenv/sql-migrate v1.7.1 h1:f/o0WgfO/GqNuVg+6801K/KW3WdDSupzSjDYODmiUq4=
 github.com/rubenv/sql-migrate v1.7.1/go.mod h1:Ob2Psprc0/3ggbM6wCzyYVFFuc6FyZrb2AS+ezLDFb4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -1874,8 +1873,6 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
-golang.org/x/crypto v0.34.0 h1:+/C6tk6rf/+t5DhUketUbD1aNGqiSX3j15Z6xuIDlBA=
-golang.org/x/crypto v0.34.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -2042,8 +2039,6 @@ golang.org/x/oauth2 v0.4.0/go.mod h1:RznEsdpjGAINPTOF0UH/t+xJ75L18YO3Ho6Pyn+uRec
 golang.org/x/oauth2 v0.5.0/go.mod h1:9/XBHVqLaWO3/BRHs5jbpYCnOZVjj5V0ndyaAM7KB4I=
 golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw=
 golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
-golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
-golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/cli/secrets/cmd.go
+++ b/pkg/cli/secrets/cmd.go
@@ -1,0 +1,76 @@
+package secrets
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+)
+
+type cmdProvider struct {
+	command string
+}
+
+// NewCmdProvider creates a new command provider.
+func NewCmdProvider(location Location) *cmdProvider {
+	p := &cmdProvider{command: string(location)}
+	p.clean()
+	return p
+}
+
+// GetSecret retrieves the secret from the command output.
+func (p *cmdProvider) GetSecret() (*Secret, error) {
+	if err := p.validate(); err != nil {
+		return nil, fmt.Errorf("validating command %q: %w", p.command, err)
+	}
+
+	cmd, err := splitCommandShellwords(p.command)
+	if err != nil {
+		return nil, fmt.Errorf("parsing command %q: %w", p.command, err)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("executing command %q: %w", p.command, err)
+	}
+	secret := strings.Trim(string(output), "\n")
+
+	return NewSecret([]byte(secret),
+		WithProvider(ProviderCmd),
+		WithLocation(Location(p.command))), nil
+}
+
+// String returns the provider ID.
+func (p *cmdProvider) String() string {
+	return ProviderCmd.String()
+}
+
+func (p *cmdProvider) clean() {
+	p.command = strings.TrimSpace(p.command)
+}
+
+func (p *cmdProvider) validate() error {
+	if p.command == "" {
+		return fmt.Errorf("command is empty")
+	}
+	return nil
+}
+
+// splitCommandShellwords splits a command into fields using shellwords.
+// shellwords handles stuff like quotes and escapes.
+func splitCommandShellwords(command string) (*exec.Cmd, error) {
+	p := shellwords.NewParser()
+	p.ParseEnv = true
+	fields, err := p.Parse(command)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	// #nosec G204 - This is a deliberate design choice to allow flexible
+	// command execution. The user should be able to run whatever they want in
+	// order to retrieve the secret.
+	cmd := exec.Command(fields[0], fields[1:]...)
+	return cmd, nil
+}

--- a/pkg/cli/secrets/cmd.go
+++ b/pkg/cli/secrets/cmd.go
@@ -19,8 +19,8 @@ func NewCmdProvider(location Location) *cmdProvider {
 	return p
 }
 
-// GetSecret retrieves the secret from the command output.
-func (p *cmdProvider) GetSecret() (*Secret, error) {
+// RetrieveSecret retrieves the secret from the command output.
+func (p *cmdProvider) RetrieveSecret() (*Secret, error) {
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating command %q: %w", p.command, err)
 	}

--- a/pkg/cli/secrets/cmd.go
+++ b/pkg/cli/secrets/cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattn/go-shellwords"
 )
 
-const ProviderCmd = "cmd"
+const SchemeCmd = "cmd"
 
 type cmdProvider struct {
 	command string
@@ -39,14 +39,17 @@ func (p *cmdProvider) RetrieveSecret(ctx context.Context, loc Location) (*Secret
 	}
 	secret := strings.Trim(string(output), "\n")
 
-	return NewSecret([]byte(secret),
-		WithProvider(ProviderCmd),
-		WithLocation(p.command)), nil
+	sl, err := NewSecretLocator(SchemeCmd, loc)
+	if err != nil {
+		return nil, fmt.Errorf("creating secret locator: %w", err)
+	}
+
+	return NewSecret([]byte(secret), WithLocator(sl)), nil
 }
 
-// String returns the provider ID.
-func (p *cmdProvider) String() string {
-	return ProviderCmd
+// String returns the scheme for the provider.
+func (p *cmdProvider) Scheme() Scheme {
+	return SchemeCmd
 }
 
 func (p *cmdProvider) clean() {

--- a/pkg/cli/secrets/cmd.go
+++ b/pkg/cli/secrets/cmd.go
@@ -16,14 +16,15 @@ type cmdProvider struct {
 }
 
 // NewCmdProvider creates a new command provider.
-func NewCmdProvider(location Location) *cmdProvider {
-	p := &cmdProvider{command: string(location)}
-	p.clean()
-	return p
+func NewCmdProvider() *cmdProvider {
+	return &cmdProvider{}
 }
 
-// RetrieveSecret retrieves the secret from the command output.
-func (p *cmdProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
+// RetrieveSecret retrieves a secret from the command output.
+func (p *cmdProvider) RetrieveSecret(ctx context.Context, loc Location) (*Secret, error) {
+	p.command = string(loc)
+	p.clean()
+
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating command %q: %w", p.command, err)
 	}
@@ -40,7 +41,7 @@ func (p *cmdProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
 
 	return NewSecret([]byte(secret),
 		WithProvider(ProviderCmd),
-		WithLocation(Location(p.command))), nil
+		WithLocation(p.command)), nil
 }
 
 // String returns the provider ID.

--- a/pkg/cli/secrets/cmd.go
+++ b/pkg/cli/secrets/cmd.go
@@ -9,6 +9,8 @@ import (
 	"github.com/mattn/go-shellwords"
 )
 
+const ProviderCmd = "cmd"
+
 type cmdProvider struct {
 	command string
 }
@@ -43,7 +45,7 @@ func (p *cmdProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
 
 // String returns the provider ID.
 func (p *cmdProvider) String() string {
-	return ProviderCmd.String()
+	return ProviderCmd
 }
 
 func (p *cmdProvider) clean() {

--- a/pkg/cli/secrets/cmd_test.go
+++ b/pkg/cli/secrets/cmd_test.go
@@ -66,7 +66,7 @@ func TestCmdProvider_GetSecret(t *testing.T) {
 			}
 		}
 		p := NewCmdProvider(tc.location)
-		secret, err := p.RetrieveSecret()
+		secret, err := p.RetrieveSecret(t.Context())
 
 		if tc.expectedErr != nil {
 			assert.EqualError(t, err, tc.expectedErr.Error())

--- a/pkg/cli/secrets/cmd_test.go
+++ b/pkg/cli/secrets/cmd_test.go
@@ -1,0 +1,80 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmdProvider_GetSecret(t *testing.T) {
+	testCases := []struct {
+		location      Location
+		expectedValue []byte
+		expectedErr   error
+		env           map[string]string
+	}{
+		{
+			location:      "echo hello",
+			expectedValue: []byte("hello"),
+			expectedErr:   nil,
+			env:           nil,
+		},
+		{
+			location:      "echo 'hello world'",
+			expectedValue: []byte("hello world"),
+			expectedErr:   nil,
+			env:           nil,
+		},
+		{
+			location:      `foo '`,
+			expectedValue: nil,
+			expectedErr:   fmt.Errorf("parsing command \"foo '\": invalid command line string"),
+			env:           nil,
+		},
+		{
+			location:      "nonexistent_command",
+			expectedValue: nil,
+			expectedErr:   fmt.Errorf("executing command \"nonexistent_command\": exec: \"nonexistent_command\": executable file not found in $PATH"),
+			env:           nil,
+		},
+		{
+			location:      "",
+			expectedValue: nil,
+			expectedErr:   fmt.Errorf("validating command \"\": command is empty"),
+			env:           nil,
+		},
+		{
+			location:      "echo \"hello world\"",
+			expectedValue: []byte("hello world"),
+			expectedErr:   nil,
+			env:           nil,
+		},
+		{
+			location:      "echo $FOO", // Test environment variable expansion
+			expectedValue: []byte("bar"),
+			expectedErr:   nil,
+			env:           map[string]string{"FOO": "bar"},
+		},
+	}
+
+	for _, tc := range testCases {
+		if tc.env != nil {
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+		}
+		p := NewCmdProvider(tc.location)
+		secret, err := p.GetSecret()
+
+		if tc.expectedErr != nil {
+			assert.EqualError(t, err, tc.expectedErr.Error())
+		} else {
+			assert.NoError(t, err)
+			if secret != nil {
+				assert.Equal(t, tc.expectedValue, secret.Value)
+			}
+		}
+	}
+}

--- a/pkg/cli/secrets/cmd_test.go
+++ b/pkg/cli/secrets/cmd_test.go
@@ -65,8 +65,8 @@ func TestCmdProvider_GetSecret(t *testing.T) {
 				os.Setenv(k, v)
 			}
 		}
-		p := NewCmdProvider(tc.location)
-		secret, err := p.RetrieveSecret(t.Context())
+		p := NewCmdProvider()
+		secret, err := p.RetrieveSecret(t.Context(), tc.location)
 
 		if tc.expectedErr != nil {
 			assert.EqualError(t, err, tc.expectedErr.Error())

--- a/pkg/cli/secrets/cmd_test.go
+++ b/pkg/cli/secrets/cmd_test.go
@@ -66,7 +66,7 @@ func TestCmdProvider_GetSecret(t *testing.T) {
 			}
 		}
 		p := NewCmdProvider(tc.location)
-		secret, err := p.GetSecret()
+		secret, err := p.RetrieveSecret()
 
 		if tc.expectedErr != nil {
 			assert.EqualError(t, err, tc.expectedErr.Error())

--- a/pkg/cli/secrets/doc.go
+++ b/pkg/cli/secrets/doc.go
@@ -1,5 +1,6 @@
 /*
-Package secrets provides a flexible way to retrieve secrets from various providers.
+Package secrets provides a flexible way to retrieve secrets from various
+providers with context-aware functionality for timeout and cancellation support.
 
 The package supports retrieving secrets from:
   - Environment variables (env://)
@@ -8,7 +9,9 @@ The package supports retrieving secrets from:
   - LastPass password manager (lp://)
 
 Each secret is identified by a URL-like string in the format "provider://location" where:
+
   - provider: is one of "env", "file", "cmd", or "lp"
+
   - location: is specific to the provider (environment variable name, file path, command, or LastPass ID)
 
 # Basic Usage
@@ -29,9 +32,92 @@ Retrieve a secret value using the GetSecretValue function:
 		return err
 	}
 
+# Context-Aware Functions
+
+For more control over timeouts and cancellation, use the WithContext variants:
+
+	// Use a custom context for secret retrieval
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	secret, err := secrets.GetSecretWithContext(ctx, "env://API_KEY")
+	if err != nil {
+		return err
+	}
+
+	// Or with direct value retrieval
+	apiKey, err := secrets.GetSecretValueWithContext(ctx, "env://API_KEY")
+	if err != nil {
+		return err
+	}
+
+Note: The non-context functions use a default timeout of 10 seconds. The default
+timeout can be changed by setting the `DefaultTimeout` variable.
+
+# Direct Identifier Usage
+
 Alternatively, create the identifier directly:
 
 	identifier := secrets.NewIdentifier(secrets.ProviderFile, "/path/to/secret")
+
+	// Use with context
+	ctx := context.Background()
+	secret, err := identifier.Provider.RetrieveSecret(ctx)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Retrieve the secret with the custom timeout
+	secret, err := secrets.GetSecretWithContext(ctx, "lp://My-Secret-Note/Password")
+	if err != nil {
+		// Handle timeout or other errors
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Fatal("Secret retrieval timed out")
+		}
+		log.Fatalf("Failed to retrieve secret: %v", err)
+	}
+
+## Cancellation
+
+Cancel the operation based on external events:
+
+	// Create a cancellable context
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Set up cancellation based on some condition
+	go func() {
+		// Monitor some condition
+		<-someConditionChannel
+		// Cancel the secret retrieval when condition is met
+		cancel()
+	}()
+
+	// Attempt to retrieve the secret
+	secret, err := secrets.GetSecretWithContext(ctx, "cmd://aws secretsmanager get-secret-value")
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.Println("Secret retrieval was cancelled")
+		}
+		// Handle other errors
+	}
+
+## Inheriting Context from Parent Operations
+
+Propagate context from parent operations:
+
+	func processWithSecrets(ctx context.Context) error {
+		// Use the parent context for secret retrieval
+		apiKey, err := secrets.GetSecretValueWithContext(ctx, "env://API_KEY")
+		if err != nil {
+			return fmt.Errorf("failed to get API key: %w", err)
+		}
+
+		// Use the secret in subsequent operations
+		return callExternalAPI(ctx, apiKey)
+	}
+
 	secret, err := identifier.Provider.RetrieveSecret()
 	if err != nil {
 		return err
@@ -42,19 +128,35 @@ Alternatively, create the identifier directly:
 Example of adding flags to a Cobra command that accept secrets:
 
 	import (
+
+		"context"
+		"errors"
+		"time"
+
 		"github.com/spf13/cobra"
 		"github.com/neticdk/go-common/pkg/cli/secrets"
+
 	)
 
 	func NewCommand() *cobra.Command {
 		var secretValue string
+		var timeout int
 
 		cmd := &cobra.Command{
 			Use:   "your-command",
 			Short: "Command that uses secrets",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				// Parse the secret identifier
+				// Use default timeout behavior
 				value, err := secrets.GetSecretValue(secretValue)
+				if err != nil {
+					return err
+				}
+
+				// Or use context for custom timeout
+				ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(timeout)*time.Second)
+				defer cancel()
+
+				value, err = secrets.GetSecretValueWithContext(ctx, secretValue)
 				if err != nil {
 					return err
 				}
@@ -65,6 +167,9 @@ Example of adding flags to a Cobra command that accept secrets:
 				return nil
 			},
 		}
+
+		// Add timeout flag
+		cmd.Flags().IntVar(&timeout, "timeout", 10, "Timeout in seconds for secret retrieval")
 
 		// Add flags that accept secrets
 		cmd.Flags().StringVar(&secretValue, "api-key", "",

--- a/pkg/cli/secrets/doc.go
+++ b/pkg/cli/secrets/doc.go
@@ -1,0 +1,103 @@
+/*
+Package secrets provides a flexible way to retrieve secrets from various providers.
+
+The package supports retrieving secrets from:
+  - Environment variables (env://)
+  - Files (file://)
+  - Command output (cmd://)
+  - LastPass password manager (lp://)
+
+Each secret is identified by a URL-like string in the format "provider://location" where:
+  - provider: is one of "env", "file", "cmd", or "lp"
+  - location: is specific to the provider (environment variable name, file path, command, or LastPass ID)
+
+# Basic Usage
+
+Retrieve a secret using the Parse function:
+
+	// Get a secret from an environment variable
+	secretIdentifier, err := secrets.Parse("env://API_KEY")
+	if err != nil {
+		return err
+	}
+
+	secret, err := secretIdentifier.GetSecret()
+	if err != nil {
+		return err
+	}
+
+	// Use the secret value
+	apiKey := secret.Value.String()
+
+Alternatively, create the identifier directly:
+
+	identifier := secrets.NewIdentifier(secrets.ProviderFile, "/path/to/secret")
+	secret, err := identifier.GetSecret()
+	if err != nil {
+		return err
+	}
+
+# Integration with Cobra CLI
+
+Example of adding flags to a Cobra command that accept secrets:
+
+	import (
+		"github.com/spf13/cobra"
+		"github.com/neticdk/go-common/pkg/cli/secrets"
+	)
+
+	func NewCommand() *cobra.Command {
+		var secretValue string
+
+		cmd := &cobra.Command{
+			Use:   "your-command",
+			Short: "Command that uses secrets",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				// Parse the secret identifier
+				identifier, err := secrets.Parse(secretValue)
+				if err != nil {
+					return err
+				}
+
+				// Get the actual secret
+				secret, err := identifier.GetSecret()
+				if err != nil {
+					return err
+				}
+
+				// Use the secret value in your command
+				// ...
+
+				return nil
+			},
+		}
+
+		// Add flags that accept secrets
+		cmd.Flags().StringVar(&secretValue, "api-key", "",
+			`API key (supports secret references like "env://API_KEY", "file:///path/to/secret",
+			"cmd://command to execute", or "lp://lastpass-id")`)
+
+		return cmd
+	}
+
+# Provider-Specific Details
+
+Environment Variables (env://):
+  - Location is the name of the environment variable
+  - Example: env://API_KEY
+
+Files (file://):
+  - Location is the absolute path to the file
+  - Example: file:///etc/secrets/api-key
+
+Commands (cmd://):
+  - Location is the command to execute
+  - The command's output to stdout is used as the secret
+  - Example: cmd://aws secretsmanager get-secret-value --secret-id my-secret --query SecretString --output text
+
+LastPass (lp://):
+  - Location is the LastPass item ID
+  - Requires the LastPass CLI (lpass) to be installed and configured
+  - Example: lp://My-Secret-Note/Password
+*/
+package secrets

--- a/pkg/cli/secrets/doc.go
+++ b/pkg/cli/secrets/doc.go
@@ -13,26 +13,26 @@ Each secret is identified by a URL-like string in the format "provider://locatio
 
 # Basic Usage
 
-Retrieve a secret using the Parse function:
+Retrieve a secret using the GetSecret function:
 
 	// Get a secret from an environment variable
-	secretIdentifier, err := secrets.Parse("env://API_KEY")
+	secret, err := secrets.GetSecret("env://API_KEY")
 	if err != nil {
 		return err
 	}
 
-	secret, err := secretIdentifier.GetSecret()
+Retrieve a secret value using the GetSecretValue function:
+
+	// Get a secret from an environment variable
+	apiKey, err := secrets.GetSecretValue("env://API_KEY")
 	if err != nil {
 		return err
 	}
-
-	// Use the secret value
-	apiKey := secret.Value.String()
 
 Alternatively, create the identifier directly:
 
 	identifier := secrets.NewIdentifier(secrets.ProviderFile, "/path/to/secret")
-	secret, err := identifier.GetSecret()
+	secret, err := identifier.Provider.RetrieveSecret()
 	if err != nil {
 		return err
 	}
@@ -54,13 +54,7 @@ Example of adding flags to a Cobra command that accept secrets:
 			Short: "Command that uses secrets",
 			RunE: func(cmd *cobra.Command, args []string) error {
 				// Parse the secret identifier
-				identifier, err := secrets.Parse(secretValue)
-				if err != nil {
-					return err
-				}
-
-				// Get the actual secret
-				secret, err := identifier.GetSecret()
+				value, err := secrets.GetSecretValue(secretValue)
 				if err != nil {
 					return err
 				}

--- a/pkg/cli/secrets/env.go
+++ b/pkg/cli/secrets/env.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const ProviderEnv = "env"
+
 type envProvider struct {
 	variable string
 }
@@ -36,7 +38,7 @@ func (p *envProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
 
 // String returns the provider ID.
 func (p *envProvider) String() string {
-	return ProviderEnv.String()
+	return ProviderEnv
 }
 
 func (p *envProvider) clean() {

--- a/pkg/cli/secrets/env.go
+++ b/pkg/cli/secrets/env.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -19,7 +20,7 @@ func NewEnvProvider(location Location) *envProvider {
 }
 
 // RetrieveSecret retrieves the secret from an environment variable.
-func (p *envProvider) RetrieveSecret() (*Secret, error) {
+func (p *envProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating environment variable %q: %w", p.variable, err)
 	}

--- a/pkg/cli/secrets/env.go
+++ b/pkg/cli/secrets/env.go
@@ -18,8 +18,8 @@ func NewEnvProvider(location Location) *envProvider {
 	return p
 }
 
-// GetSecret retrieves the secret from an environment variable.
-func (p *envProvider) GetSecret() (*Secret, error) {
+// RetrieveSecret retrieves the secret from an environment variable.
+func (p *envProvider) RetrieveSecret() (*Secret, error) {
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating environment variable %q: %w", p.variable, err)
 	}

--- a/pkg/cli/secrets/env.go
+++ b/pkg/cli/secrets/env.go
@@ -15,14 +15,15 @@ type envProvider struct {
 }
 
 // NewEnvProvider creates a new environment variable provider.
-func NewEnvProvider(location Location) *envProvider {
-	p := &envProvider{variable: string(location)}
-	p.clean()
-	return p
+func NewEnvProvider() *envProvider {
+	return &envProvider{}
 }
 
-// RetrieveSecret retrieves the secret from an environment variable.
-func (p *envProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
+// RetrieveSecret retrieves a secret from an environment variable.
+func (p *envProvider) RetrieveSecret(_ context.Context, loc Location) (*Secret, error) {
+	p.variable = string(loc)
+	p.clean()
+
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating environment variable %q: %w", p.variable, err)
 	}
@@ -33,7 +34,7 @@ func (p *envProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
 	}
 	return NewSecret([]byte(v),
 		WithProvider(ProviderEnv),
-		WithLocation(Location(p.variable))), nil
+		WithLocation(p.variable)), nil
 }
 
 // String returns the provider ID.

--- a/pkg/cli/secrets/env.go
+++ b/pkg/cli/secrets/env.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const ProviderEnv = "env"
+const SchemeEnv = "env"
 
 type envProvider struct {
 	variable string
@@ -32,14 +32,18 @@ func (p *envProvider) RetrieveSecret(_ context.Context, loc Location) (*Secret, 
 	if v == "" {
 		return nil, fmt.Errorf("missing environment variable %q", p.variable)
 	}
-	return NewSecret([]byte(v),
-		WithProvider(ProviderEnv),
-		WithLocation(p.variable)), nil
+
+	sl, err := NewSecretLocator(SchemeEnv, loc)
+	if err != nil {
+		return nil, fmt.Errorf("creating secret locator: %w", err)
+	}
+
+	return NewSecret([]byte(v), WithLocator(sl)), nil
 }
 
-// String returns the provider ID.
-func (p *envProvider) String() string {
-	return ProviderEnv
+// String returns the scheme for the provider.
+func (p *envProvider) Scheme() Scheme {
+	return SchemeEnv
 }
 
 func (p *envProvider) clean() {

--- a/pkg/cli/secrets/env.go
+++ b/pkg/cli/secrets/env.go
@@ -1,0 +1,51 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type envProvider struct {
+	variable string
+}
+
+// NewEnvProvider creates a new environment variable provider.
+func NewEnvProvider(location Location) *envProvider {
+	p := &envProvider{variable: string(location)}
+	p.clean()
+	return p
+}
+
+// GetSecret retrieves the secret from an environment variable.
+func (p *envProvider) GetSecret() (*Secret, error) {
+	if err := p.validate(); err != nil {
+		return nil, fmt.Errorf("validating environment variable %q: %w", p.variable, err)
+	}
+
+	v := os.Getenv(p.variable)
+	if v == "" {
+		return nil, fmt.Errorf("missing environment variable %q", p.variable)
+	}
+	return NewSecret([]byte(v),
+		WithProvider(ProviderEnv),
+		WithLocation(Location(p.variable))), nil
+}
+
+// String returns the provider ID.
+func (p *envProvider) String() string {
+	return ProviderEnv.String()
+}
+
+func (p *envProvider) clean() {
+	p.variable = strings.TrimSpace(p.variable)
+}
+
+func (p *envProvider) validate() error {
+	matched, _ := regexp.MatchString(`^\w+$`, p.variable)
+	if !matched {
+		return fmt.Errorf("invalid environment variable name: %s", p.variable)
+	}
+	return nil
+}

--- a/pkg/cli/secrets/env_test.go
+++ b/pkg/cli/secrets/env_test.go
@@ -1,0 +1,67 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvProvider_GetSecret(t *testing.T) {
+	setEnv := func(key, value string) {
+		os.Setenv(key, value)
+		t.Cleanup(func() {
+			os.Unsetenv(key)
+		})
+	}
+
+	tests := []struct {
+		name        string
+		location    Location
+		expected    *Secret
+		expectedErr error
+	}{
+		{
+			name:     "Valid environment variable",
+			location: "TEST_SECRET",
+			expected: NewSecret([]byte("test_value"),
+				WithProvider(ProviderEnv),
+				WithLocation("TEST_SECRET")),
+			expectedErr: nil,
+		},
+		{
+			name:        "Missing environment variable",
+			location:    "MISSING_SECRET",
+			expected:    nil,
+			expectedErr: fmt.Errorf("missing environment variable \"MISSING_SECRET\""),
+		},
+		{
+			name:        "Invalid environment variable name",
+			location:    "INVALID SECRET",
+			expected:    nil,
+			expectedErr: fmt.Errorf("validating environment variable \"INVALID SECRET\": invalid environment variable name: INVALID SECRET"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.expected != nil {
+				setEnv(string(test.location), string(test.expected.Value))
+			}
+
+			p := NewEnvProvider(test.location)
+			secret, err := p.GetSecret()
+
+			if test.expectedErr != nil {
+				assert.Error(t, err)
+				if err != nil { // Check to avoid panic if err is nil unexpectedly
+					assert.EqualError(t, err, test.expectedErr.Error())
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, secret)
+			}
+		})
+	}
+}

--- a/pkg/cli/secrets/env_test.go
+++ b/pkg/cli/secrets/env_test.go
@@ -50,8 +50,8 @@ func TestEnvProvider_GetSecret(t *testing.T) {
 				setEnv(string(test.location), string(test.expected.Value))
 			}
 
-			p := NewEnvProvider(test.location)
-			secret, err := p.RetrieveSecret(t.Context())
+			p := NewEnvProvider()
+			secret, err := p.RetrieveSecret(t.Context(), test.location)
 
 			if test.expectedErr != nil {
 				assert.Error(t, err)

--- a/pkg/cli/secrets/env_test.go
+++ b/pkg/cli/secrets/env_test.go
@@ -51,7 +51,7 @@ func TestEnvProvider_GetSecret(t *testing.T) {
 			}
 
 			p := NewEnvProvider(test.location)
-			secret, err := p.RetrieveSecret()
+			secret, err := p.RetrieveSecret(t.Context())
 
 			if test.expectedErr != nil {
 				assert.Error(t, err)

--- a/pkg/cli/secrets/env_test.go
+++ b/pkg/cli/secrets/env_test.go
@@ -26,8 +26,7 @@ func TestEnvProvider_GetSecret(t *testing.T) {
 			name:     "Valid environment variable",
 			location: "TEST_SECRET",
 			expected: NewSecret([]byte("test_value"),
-				WithProvider(ProviderEnv),
-				WithLocation("TEST_SECRET")),
+				WithLocator(&SecretLocator{Scheme: SchemeEnv, Location: "TEST_SECRET"})),
 			expectedErr: nil,
 		},
 		{
@@ -60,7 +59,9 @@ func TestEnvProvider_GetSecret(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, test.expected, secret)
+				assert.Equal(t, test.expected.GetLocation(), secret.GetLocation())
+				assert.Equal(t, test.expected.GetScheme(), secret.GetScheme())
+				assert.Equal(t, test.expected.Value, secret.Value)
 			}
 		})
 	}

--- a/pkg/cli/secrets/env_test.go
+++ b/pkg/cli/secrets/env_test.go
@@ -51,7 +51,7 @@ func TestEnvProvider_GetSecret(t *testing.T) {
 			}
 
 			p := NewEnvProvider(test.location)
-			secret, err := p.GetSecret()
+			secret, err := p.RetrieveSecret()
 
 			if test.expectedErr != nil {
 				assert.Error(t, err)

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -21,7 +22,7 @@ func NewFileProvider(location Location) *fileProvider {
 }
 
 // RetrieveSecret retrieves the secret from a file.
-func (p *fileProvider) RetrieveSecret() (*Secret, error) {
+func (p *fileProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating file %q: %w", p.path, err)
 	}

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ProviderFile      = "file"
+	SchemeFile        = "file"
 	worldReadablePerm = 0o004
 )
 
@@ -40,14 +40,17 @@ func (p *fileProvider) RetrieveSecret(_ context.Context, loc Location) (*Secret,
 		return nil, fmt.Errorf("reading file %q: %w", p.path, err)
 	}
 
-	return NewSecret(content,
-		WithProvider(ProviderFile),
-		WithLocation(p.path)), nil
+	sl, err := NewSecretLocator(SchemeFile, loc)
+	if err != nil {
+		return nil, fmt.Errorf("creating secret locator: %w", err)
+	}
+
+	return NewSecret(content, WithLocator(sl)), nil
 }
 
-// String returns the provider ID.
-func (p *fileProvider) String() string {
-	return ProviderFile
+// Scheme returns the scheme for the provider.
+func (p *fileProvider) Scheme() Scheme {
+	return SchemeFile
 }
 
 func (p *fileProvider) clean() {

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -18,14 +18,15 @@ type fileProvider struct {
 }
 
 // NewFileProvider creates a new file provider.
-func NewFileProvider(location Location) *fileProvider {
-	p := &fileProvider{path: string(location)}
-	p.clean()
-	return p
+func NewFileProvider() *fileProvider {
+	return &fileProvider{}
 }
 
-// RetrieveSecret retrieves the secret from a file.
-func (p *fileProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
+// RetrieveSecret retrieves a secret from a file.
+func (p *fileProvider) RetrieveSecret(_ context.Context, loc Location) (*Secret, error) {
+	p.path = string(loc)
+	p.clean()
+
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating file %q: %w", p.path, err)
 	}
@@ -41,7 +42,7 @@ func (p *fileProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
 
 	return NewSecret(content,
 		WithProvider(ProviderFile),
-		WithLocation(Location(p.path))), nil
+		WithLocation(p.path)), nil
 }
 
 // String returns the provider ID.

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -18,8 +18,8 @@ func NewFileProvider(location Location) *fileProvider {
 	return p
 }
 
-// GetSecret retrieves the secret from a file.
-func (p *fileProvider) GetSecret() (*Secret, error) {
+// RetrieveSecret retrieves the secret from a file.
+func (p *fileProvider) RetrieveSecret() (*Secret, error) {
 	if err := p.validate(); err != nil {
 		return nil, fmt.Errorf("validating file %q: %w", p.path, err)
 	}
@@ -67,5 +67,10 @@ func (p *fileProvider) checkFile() error {
 		return fmt.Errorf("file %q is not a regular file", p.path)
 	}
 
+	// Check if file is world-readable
+	mode := info.Mode().Perm()
+	if mode&0o004 != 0 {
+		return fmt.Errorf("file %q has insecure permissions (world-readable): %v", p.path, mode)
+	}
 	return nil
 }

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -1,0 +1,71 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type fileProvider struct {
+	path string
+}
+
+// NewFileProvider creates a new file provider.
+func NewFileProvider(location Location) *fileProvider {
+	p := &fileProvider{path: string(location)}
+	p.clean()
+	return p
+}
+
+// GetSecret retrieves the secret from a file.
+func (p *fileProvider) GetSecret() (*Secret, error) {
+	if err := p.validate(); err != nil {
+		return nil, fmt.Errorf("validating file %q: %w", p.path, err)
+	}
+
+	if err := p.checkFile(); err != nil {
+		return nil, err
+	}
+
+	content, err := os.ReadFile(p.path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %q: %w", p.path, err)
+	}
+
+	return NewSecret(content,
+		WithProvider(ProviderFile),
+		WithLocation(Location(p.path))), nil
+}
+
+// String returns the provider ID.
+func (p *fileProvider) String() string {
+	return ProviderFile.String()
+}
+
+func (p *fileProvider) clean() {
+	p.path = filepath.Clean(p.path)
+}
+
+func (p *fileProvider) validate() error {
+	if filepath.IsAbs(p.path) {
+		return nil
+	}
+	return fmt.Errorf("invalid file path: %s", p.path)
+}
+
+func (p *fileProvider) checkFile() error {
+	info, err := os.Stat(p.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("file %q does not exist", p.path)
+		}
+		return fmt.Errorf("checking if file %q exists: %w", p.path, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("file %q is not a regular file", p.path)
+	}
+
+	return nil
+}

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -8,7 +8,10 @@ import (
 	"path/filepath"
 )
 
-const worldReadablePerm = 0o004
+const (
+	ProviderFile      = "file"
+	worldReadablePerm = 0o004
+)
 
 type fileProvider struct {
 	path string
@@ -43,7 +46,7 @@ func (p *fileProvider) RetrieveSecret(_ context.Context) (*Secret, error) {
 
 // String returns the provider ID.
 func (p *fileProvider) String() string {
-	return ProviderFile.String()
+	return ProviderFile
 }
 
 func (p *fileProvider) clean() {

--- a/pkg/cli/secrets/file.go
+++ b/pkg/cli/secrets/file.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 )
 
+const worldReadablePerm = 0o004
+
 type fileProvider struct {
 	path string
 }
@@ -69,7 +71,7 @@ func (p *fileProvider) checkFile() error {
 
 	// Check if file is world-readable
 	mode := info.Mode().Perm()
-	if mode&0o004 != 0 {
+	if mode&worldReadablePerm != 0 {
 		return fmt.Errorf("file %q has insecure permissions (world-readable): %v", p.path, mode)
 	}
 	return nil

--- a/pkg/cli/secrets/file_test.go
+++ b/pkg/cli/secrets/file_test.go
@@ -26,7 +26,7 @@ func (suite *FileProviderTestSuite) TestGetSecret_Success() {
 	err := os.WriteFile(filePath, secretContent, 0o600)
 	suite.Require().NoError(err)
 
-	secret, err := provider.RetrieveSecret()
+	secret, err := provider.RetrieveSecret(suite.T().Context())
 
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), secretContent, secret.Value)
@@ -38,7 +38,7 @@ func (suite *FileProviderTestSuite) TestGetSecret_FileNotFound() {
 	filePath := filepath.Join(suite.testDir, "non_existent_file.txt")
 	provider := NewFileProvider(Location(filePath))
 
-	secret, err := provider.RetrieveSecret()
+	secret, err := provider.RetrieveSecret(suite.T().Context())
 
 	suite.Require().Error(err)
 	assert.Nil(suite.T(), secret)
@@ -53,7 +53,7 @@ func (suite *FileProviderTestSuite) TestGetSecret_FileNotRegular() {
 	err := os.Mkdir(filePath, 0o700)
 	suite.Require().NoError(err)
 
-	secret, err := provider.RetrieveSecret()
+	secret, err := provider.RetrieveSecret(suite.T().Context())
 
 	suite.Require().Error(err)
 	assert.Nil(suite.T(), secret)
@@ -64,7 +64,7 @@ func (suite *FileProviderTestSuite) TestGetSecret_FileNotRegular() {
 func (suite *FileProviderTestSuite) TestGetSecret_InvalidPath() {
 	provider := NewFileProvider(Location("invalid/relative/path"))
 
-	secret, err := provider.RetrieveSecret()
+	secret, err := provider.RetrieveSecret(suite.T().Context())
 
 	assert.Nil(suite.T(), secret)
 	suite.Require().Error(err)
@@ -92,7 +92,7 @@ func (suite *FileProviderTestSuite) TestGetSecret_ErrorCheckingFileStats() {
 	err = os.Chmod(filepath.Dir(filePath), 0o000) // remove permissions to trigger an error from stat
 	suite.Require().NoError(err, "failed to set no permissions on test directory")
 
-	_, err = provider.RetrieveSecret()
+	_, err = provider.RetrieveSecret(suite.T().Context())
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "checking if file")
@@ -106,7 +106,7 @@ func (suite *FileProviderTestSuite) TestGetSecret_InsecurePermissions() {
 	err := os.WriteFile(filePath, secretContent, 0o644) // World-readable permissions
 	suite.Require().NoError(err)
 
-	secret, err := provider.RetrieveSecret()
+	secret, err := provider.RetrieveSecret(suite.T().Context())
 
 	suite.Require().Error(err)
 	assert.Nil(suite.T(), secret)

--- a/pkg/cli/secrets/file_test.go
+++ b/pkg/cli/secrets/file_test.go
@@ -30,8 +30,8 @@ func (suite *FileProviderTestSuite) TestGetSecret_Success() {
 
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), secretContent, secret.Value)
-	assert.Equal(suite.T(), ProviderFile, secret.Provider)
-	assert.Equal(suite.T(), filePath, secret.Location)
+	assert.Equal(suite.T(), Scheme(SchemeFile), secret.GetScheme())
+	assert.Equal(suite.T(), Location(filePath), secret.GetLocation())
 }
 
 func (suite *FileProviderTestSuite) TestGetSecret_FileNotFound() {

--- a/pkg/cli/secrets/file_test.go
+++ b/pkg/cli/secrets/file_test.go
@@ -1,0 +1,103 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type FileProviderTestSuite struct {
+	suite.Suite
+	testDir string
+}
+
+func (suite *FileProviderTestSuite) SetupSuite() {
+	suite.testDir = suite.T().TempDir()
+}
+
+func (suite *FileProviderTestSuite) TestGetSecret_Success() {
+	filePath := filepath.Join(suite.testDir, "test_secret.txt")
+	provider := NewFileProvider(Location(filePath))
+	secretContent := []byte("test_secret_value")
+
+	err := os.WriteFile(filePath, secretContent, 0o600)
+	suite.Require().NoError(err)
+
+	secret, err := provider.GetSecret()
+
+	suite.Require().NoError(err)
+	assert.Equal(suite.T(), secretContent, secret.Value)
+	assert.Equal(suite.T(), ProviderFile, secret.Provider)
+	assert.Equal(suite.T(), Location(filePath), secret.Location)
+}
+
+func (suite *FileProviderTestSuite) TestGetSecret_FileNotFound() {
+	filePath := filepath.Join(suite.testDir, "non_existent_file.txt")
+	provider := NewFileProvider(Location(filePath))
+
+	secret, err := provider.GetSecret()
+
+	suite.Require().Error(err)
+	assert.Nil(suite.T(), secret)
+	assert.Contains(suite.T(), err.Error(), "file \"")
+	assert.Contains(suite.T(), err.Error(), "\" does not exist")
+}
+
+func (suite *FileProviderTestSuite) TestGetSecret_FileNotRegular() {
+	filePath := filepath.Join(suite.testDir, "test_dir")
+	provider := NewFileProvider(Location(filePath))
+
+	err := os.Mkdir(filePath, 0o700)
+	suite.Require().NoError(err)
+
+	secret, err := provider.GetSecret()
+
+	suite.Require().Error(err)
+	assert.Nil(suite.T(), secret)
+	assert.Contains(suite.T(), err.Error(), "file \"")
+	assert.Contains(suite.T(), err.Error(), "\" is not a regular file")
+}
+
+func (suite *FileProviderTestSuite) TestGetSecret_InvalidPath() {
+	provider := NewFileProvider(Location("invalid/relative/path"))
+
+	secret, err := provider.GetSecret()
+
+	assert.Nil(suite.T(), secret)
+	suite.Require().Error(err)
+	assert.Contains(suite.T(), err.Error(), "invalid file path: invalid/relative/path")
+}
+
+func (suite *FileProviderTestSuite) TestGetSecret_ErrorCheckingFileStats() {
+	filePath := filepath.Join(suite.testDir, "secret.txt")
+	provider := NewFileProvider(Location(filePath))
+
+	// Create a directory with restricted permissions.
+	err := os.MkdirAll(filepath.Dir(filePath), 0o700)
+	suite.Require().NoError(err, "failed to create test directory")
+	defer func() {
+		// Restore permissions to cleanup
+		err := os.Chmod(filepath.Dir(filePath), 0o700)
+		suite.Require().NoError(err, "failed to cleanup test directory")
+	}()
+
+	secretContent := []byte("test_secret_value")
+
+	err = os.WriteFile(filePath, secretContent, 0o600)
+	suite.Require().NoError(err)
+
+	err = os.Chmod(filepath.Dir(filePath), 0o000) // remove permissions to trigger an error from stat
+	suite.Require().NoError(err, "failed to set no permissions on test directory")
+
+	_, err = provider.GetSecret()
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "checking if file")
+}
+
+func TestFileProviderTestSuite(t *testing.T) {
+	suite.Run(t, new(FileProviderTestSuite))
+}

--- a/pkg/cli/secrets/identifier.go
+++ b/pkg/cli/secrets/identifier.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -27,19 +28,19 @@ func (i *Identifier) String() string {
 
 // GetSecret retrieves the secret from the provider.
 // It's a convenience method for retrieving the secret.
-func (i *Identifier) GetSecret() (*Secret, error) {
+func (i *Identifier) GetSecret(ctx context.Context) (*Secret, error) {
 	if i.Provider == nil {
 		return nil, fmt.Errorf("missing provider")
 	}
-	return i.Provider.RetrieveSecret()
+	return i.Provider.RetrieveSecret(ctx)
 }
 
 // GetSecretValue retrieves the secret value from the provider.
-func (i *Identifier) GetSecretValue() (string, error) {
+func (i *Identifier) GetSecretValue(ctx context.Context) (string, error) {
 	if i.Provider == nil {
 		return "", fmt.Errorf("missing provider")
 	}
-	secret, err := i.Provider.RetrieveSecret()
+	secret, err := i.Provider.RetrieveSecret(ctx)
 	if err != nil {
 		return "", fmt.Errorf("retrieving secret: %w", err)
 	}

--- a/pkg/cli/secrets/identifier.go
+++ b/pkg/cli/secrets/identifier.go
@@ -26,8 +26,24 @@ func (i *Identifier) String() string {
 }
 
 // GetSecret retrieves the secret from the provider.
+// It's a convenience method for retrieving the secret.
 func (i *Identifier) GetSecret() (*Secret, error) {
-	return i.Provider.GetSecret()
+	if i.Provider == nil {
+		return nil, fmt.Errorf("missing provider")
+	}
+	return i.Provider.RetrieveSecret()
+}
+
+// GetSecretValue retrieves the secret value from the provider.
+func (i *Identifier) GetSecretValue() (string, error) {
+	if i.Provider == nil {
+		return "", fmt.Errorf("missing provider")
+	}
+	secret, err := i.Provider.RetrieveSecret()
+	if err != nil {
+		return "", fmt.Errorf("retrieving secret: %w", err)
+	}
+	return secret.String(), nil
 }
 
 // NewIdentifier creates a new identifier.

--- a/pkg/cli/secrets/identifier.go
+++ b/pkg/cli/secrets/identifier.go
@@ -1,0 +1,53 @@
+package secrets
+
+import (
+	"fmt"
+)
+
+// Location is a string that represents the location of a secret.
+type Location string
+
+// Identifier is a reference to a secret.
+type Identifier struct {
+	// Provider implements the provider for the identifier.
+	Provider Provider
+
+	// Location is the location of the secret within the provider.
+	Location Location
+}
+
+// String returns the string representation of the identifier.
+func (i *Identifier) String() string {
+	var provider string
+	if i.Provider != nil {
+		provider = i.Provider.String()
+	}
+	return fmt.Sprintf("%s://%s", provider, i.Location)
+}
+
+// GetSecret retrieves the secret from the provider.
+func (i *Identifier) GetSecret() (*Secret, error) {
+	return i.Provider.GetSecret()
+}
+
+// NewIdentifier creates a new identifier.
+func NewIdentifier(providerID ProviderID, location Location) *Identifier {
+	provider := NewProvider(providerID, location)
+	i := &Identifier{
+		Location: location,
+		Provider: provider,
+	}
+	return i
+}
+
+// Validate validates the identifier.
+func (i *Identifier) Validate() error {
+	if i.Provider == nil {
+		return fmt.Errorf("missing provider")
+	}
+
+	if i.Location == "" {
+		return fmt.Errorf("missing location")
+	}
+	return nil
+}

--- a/pkg/cli/secrets/identifier.go
+++ b/pkg/cli/secrets/identifier.go
@@ -48,13 +48,16 @@ func (i *Identifier) GetSecretValue(ctx context.Context) (string, error) {
 }
 
 // NewIdentifier creates a new identifier.
-func NewIdentifier(providerID ProviderID, location Location) *Identifier {
-	provider := NewProvider(providerID, location)
+func NewIdentifier(scheme string, location Location) (*Identifier, error) {
+	provider, err := NewProvider(scheme, location)
+	if err != nil {
+		return nil, fmt.Errorf("creating provider: %w", err)
+	}
 	i := &Identifier{
 		Location: location,
 		Provider: provider,
 	}
-	return i
+	return i, nil
 }
 
 // Validate validates the identifier.

--- a/pkg/cli/secrets/identifier.go
+++ b/pkg/cli/secrets/identifier.go
@@ -53,11 +53,10 @@ func NewIdentifier(scheme string, location Location) (*Identifier, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating provider: %w", err)
 	}
-	i := &Identifier{
+	return &Identifier{
 		Location: location,
 		Provider: provider,
-	}
-	return i, nil
+	}, nil
 }
 
 // Validate validates the identifier.

--- a/pkg/cli/secrets/identifier_test.go
+++ b/pkg/cli/secrets/identifier_test.go
@@ -1,0 +1,114 @@
+package secrets
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentifierString(t *testing.T) {
+	tests := []struct {
+		provider Provider
+		location Location
+		expected string
+	}{
+		{
+			provider: NewProvider(ProviderEnv, Location("MY_SECRET")),
+			location: Location("MY_SECRET"),
+			expected: "env://MY_SECRET",
+		},
+		{
+			provider: NewProvider(ProviderFile, Location("/path/to/secret.txt")),
+			location: Location("/path/to/secret.txt"),
+			expected: "file:///path/to/secret.txt",
+		},
+		{
+			provider: NewProvider(ProviderCmd, Location("get secret")),
+			location: Location("get secret"),
+			expected: "cmd://get secret",
+		},
+		{
+			provider: NewProvider(ProviderLastPass, Location("12345")),
+			location: Location("12345"),
+			expected: "lp://12345",
+		},
+		{
+			provider: NewProvider(ProviderUnknown, Location("")),
+			location: Location(""),
+			expected: "://",
+		},
+	}
+
+	for _, test := range tests {
+		identifier := &Identifier{Provider: test.provider, Location: test.location}
+		assert.Equal(t, test.expected, identifier.String())
+	}
+}
+
+func TestNewIdentifier(t *testing.T) {
+	tests := []struct {
+		providerID ProviderID
+		location   Location
+		isValid    bool
+	}{
+		{
+			providerID: ProviderEnv,
+			location:   Location("MY_SECRET"),
+			isValid:    true,
+		},
+		{
+			providerID: ProviderFile,
+			location:   Location("/path/to/secret.txt"),
+			isValid:    true,
+		},
+		{
+			providerID: ProviderCmd,
+			location:   Location("get secret"),
+			isValid:    true,
+		},
+		{
+			providerID: ProviderLastPass,
+			location:   Location("12345"),
+			isValid:    true,
+		},
+		{
+			providerID: ProviderID(""),
+			location:   Location("another-secret"),
+			isValid:    false,
+		},
+	}
+	for _, test := range tests {
+		identifier := NewIdentifier(test.providerID, test.location)
+
+		if test.isValid {
+			assert.NotNil(t, identifier.Provider)
+		} else {
+			assert.Nil(t, identifier.Provider)
+		}
+	}
+}
+
+func TestIdentifierValidate(t *testing.T) {
+	tests := []struct {
+		identifier *Identifier
+		expected   error
+	}{
+		{
+			identifier: &Identifier{},
+			expected:   fmt.Errorf("missing provider"),
+		},
+		{
+			identifier: &Identifier{Provider: NewProvider(ProviderEnv, Location(""))},
+			expected:   fmt.Errorf("missing location"),
+		},
+		{
+			identifier: &Identifier{Provider: NewProvider(ProviderEnv, Location("MY_SECRET")), Location: "MY_SECRET"},
+			expected:   nil,
+		},
+	}
+	for _, test := range tests {
+		err := test.identifier.Validate()
+		assert.Equal(t, test.expected, err)
+	}
+}

--- a/pkg/cli/secrets/identifier_test.go
+++ b/pkg/cli/secrets/identifier_test.go
@@ -122,7 +122,7 @@ func TestIdentifierGetSecret(t *testing.T) {
 			Location: "test-location",
 		}
 
-		secret, err := identifier.GetSecret()
+		secret, err := identifier.GetSecret(t.Context())
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing provider")
@@ -152,7 +152,7 @@ func TestIdentifierGetSecret(t *testing.T) {
 		}
 
 		// Test secret retrieval
-		secret, err := identifier.GetSecret()
+		secret, err := identifier.GetSecret(t.Context())
 
 		assert.NoError(t, err)
 		assert.NotNil(t, secret)
@@ -168,7 +168,7 @@ func TestIdentifierGetSecret(t *testing.T) {
 			Location: Location(nonExistentPath),
 		}
 
-		secret, err := identifier.GetSecret()
+		secret, err := identifier.GetSecret(t.Context())
 
 		assert.Error(t, err)
 		assert.Nil(t, secret)
@@ -183,7 +183,7 @@ func TestIdentifierGetSecretValue(t *testing.T) {
 			Location: "test-location",
 		}
 
-		value, err := identifier.GetSecretValue()
+		value, err := identifier.GetSecretValue(t.Context())
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing provider")
@@ -213,7 +213,7 @@ func TestIdentifierGetSecretValue(t *testing.T) {
 		}
 
 		// Test secret value retrieval
-		value, err := identifier.GetSecretValue()
+		value, err := identifier.GetSecretValue(t.Context())
 
 		assert.NoError(t, err)
 		assert.Equal(t, testContent, value)
@@ -228,7 +228,7 @@ func TestIdentifierGetSecretValue(t *testing.T) {
 			Location: Location(nonExistentPath),
 		}
 
-		value, err := identifier.GetSecretValue()
+		value, err := identifier.GetSecretValue(t.Context())
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "retrieving secret:")

--- a/pkg/cli/secrets/identifier_test.go
+++ b/pkg/cli/secrets/identifier_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,4 +112,126 @@ func TestIdentifierValidate(t *testing.T) {
 		err := test.identifier.Validate()
 		assert.Equal(t, test.expected, err)
 	}
+}
+
+func TestIdentifierGetSecret(t *testing.T) {
+	// Test for nil provider
+	t.Run("nil provider", func(t *testing.T) {
+		identifier := &Identifier{
+			Provider: nil,
+			Location: "test-location",
+		}
+
+		secret, err := identifier.GetSecret()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing provider")
+		assert.Nil(t, secret)
+	})
+
+	// Test with actual file provider
+	t.Run("file provider with existing file", func(t *testing.T) {
+		// Create a temporary file with test content
+		tempFile, err := os.CreateTemp("", "secret-test-*")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		// Write test content
+		testContent := "test-secret-value"
+		if _, err := tempFile.WriteString(testContent); err != nil {
+			t.Fatalf("Failed to write to temp file: %v", err)
+		}
+		tempFile.Close()
+
+		// Create identifier with file provider
+		identifier := &Identifier{
+			Provider: NewProvider(ProviderFile, Location(tempFile.Name())),
+			Location: Location(tempFile.Name()),
+		}
+
+		// Test secret retrieval
+		secret, err := identifier.GetSecret()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, secret)
+		assert.Equal(t, testContent, secret.String())
+	})
+
+	// Test with file provider pointing to non-existent file
+	t.Run("file provider with non-existent file", func(t *testing.T) {
+		nonExistentPath := "/path/to/nonexistent/file"
+
+		identifier := &Identifier{
+			Provider: NewProvider(ProviderFile, Location(nonExistentPath)),
+			Location: Location(nonExistentPath),
+		}
+
+		secret, err := identifier.GetSecret()
+
+		assert.Error(t, err)
+		assert.Nil(t, secret)
+	})
+}
+
+func TestIdentifierGetSecretValue(t *testing.T) {
+	// Test for nil provider
+	t.Run("nil provider", func(t *testing.T) {
+		identifier := &Identifier{
+			Provider: nil,
+			Location: "test-location",
+		}
+
+		value, err := identifier.GetSecretValue()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing provider")
+		assert.Equal(t, "", value)
+	})
+
+	// Test with actual file provider
+	t.Run("file provider with existing file", func(t *testing.T) {
+		// Create a temporary file with test content
+		tempFile, err := os.CreateTemp("", "secret-test-*")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		// Write test content
+		testContent := "test-secret-value"
+		if _, err := tempFile.WriteString(testContent); err != nil {
+			t.Fatalf("Failed to write to temp file: %v", err)
+		}
+		tempFile.Close()
+
+		// Create identifier with file provider
+		identifier := &Identifier{
+			Provider: NewProvider(ProviderFile, Location(tempFile.Name())),
+			Location: Location(tempFile.Name()),
+		}
+
+		// Test secret value retrieval
+		value, err := identifier.GetSecretValue()
+
+		assert.NoError(t, err)
+		assert.Equal(t, testContent, value)
+	})
+
+	// Test with file provider pointing to non-existent file
+	t.Run("file provider with non-existent file", func(t *testing.T) {
+		nonExistentPath := "/path/to/nonexistent/file"
+
+		identifier := &Identifier{
+			Provider: NewProvider(ProviderFile, Location(nonExistentPath)),
+			Location: Location(nonExistentPath),
+		}
+
+		value, err := identifier.GetSecretValue()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "retrieving secret:")
+		assert.Equal(t, "", value)
+	})
 }

--- a/pkg/cli/secrets/lastpass.go
+++ b/pkg/cli/secrets/lastpass.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 )
 
 // execCommand is used for mocking in tests.
@@ -23,9 +22,7 @@ func NewLastPassProvider(location Location) *lastPassProvider {
 }
 
 // RetrieveSecret retrieves the secret from LastPass using the password field.
-func (p *lastPassProvider) RetrieveSecret() (*Secret, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+func (p *lastPassProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
 	cmd := execCommand(ctx, "lpass", "show", "--password", p.id)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/cli/secrets/lastpass.go
+++ b/pkg/cli/secrets/lastpass.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const ProviderLastPass = "lp"
+const SchemeLastPass = "lp"
 
 // execCommand is used for mocking in tests.
 var execCommand = exec.CommandContext
@@ -33,14 +33,17 @@ func (p *lastPassProvider) RetrieveSecret(ctx context.Context, loc Location) (*S
 	}
 	secret := strings.Trim(string(output), "\n")
 
-	return NewSecret([]byte(secret),
-		WithProvider(ProviderLastPass),
-		WithLocation(p.id)), nil
+	sl, err := NewSecretLocator(SchemeLastPass, loc)
+	if err != nil {
+		return nil, fmt.Errorf("creating secret locator: %w", err)
+	}
+
+	return NewSecret([]byte(secret), WithLocator(sl)), nil
 }
 
-// String returns the provider ID.
-func (p *lastPassProvider) String() string {
-	return ProviderLastPass
+// String returns the scheme for the provider.
+func (p *lastPassProvider) Scheme() Scheme {
+	return SchemeLastPass
 }
 
 func (p *lastPassProvider) clean() {

--- a/pkg/cli/secrets/lastpass.go
+++ b/pkg/cli/secrets/lastpass.go
@@ -1,0 +1,44 @@
+package secrets
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// execCommand is used for mocking in tests.
+var execCommand = exec.Command
+
+type lastPassProvider struct {
+	id string
+}
+
+// NewLastPassProvider creates a new LastPass provider.
+func NewLastPassProvider(location Location) *lastPassProvider {
+	p := &lastPassProvider{id: string(location)}
+	p.clean()
+	return p
+}
+
+// GetSecret retrieves the secret from LastPass using the password field.
+func (p *lastPassProvider) GetSecret() (*Secret, error) {
+	cmd := execCommand("lpass", "show", "--password", p.id)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("executing command %q: %w", cmd.String(), err)
+	}
+	secret := strings.Trim(string(output), "\n")
+
+	return NewSecret([]byte(secret),
+		WithProvider(ProviderLastPass),
+		WithLocation(Location(p.id))), nil
+}
+
+// String returns the provider ID.
+func (p *lastPassProvider) String() string {
+	return ProviderLastPass.String()
+}
+
+func (p *lastPassProvider) clean() {
+	p.id = strings.TrimSpace(p.id)
+}

--- a/pkg/cli/secrets/lastpass.go
+++ b/pkg/cli/secrets/lastpass.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const ProviderLastPass = "lp"
+
 // execCommand is used for mocking in tests.
 var execCommand = exec.CommandContext
 
@@ -37,7 +39,7 @@ func (p *lastPassProvider) RetrieveSecret(ctx context.Context) (*Secret, error) 
 
 // String returns the provider ID.
 func (p *lastPassProvider) String() string {
-	return ProviderLastPass.String()
+	return ProviderLastPass
 }
 
 func (p *lastPassProvider) clean() {

--- a/pkg/cli/secrets/lastpass.go
+++ b/pkg/cli/secrets/lastpass.go
@@ -17,14 +17,15 @@ type lastPassProvider struct {
 }
 
 // NewLastPassProvider creates a new LastPass provider.
-func NewLastPassProvider(location Location) *lastPassProvider {
-	p := &lastPassProvider{id: string(location)}
-	p.clean()
-	return p
+func NewLastPassProvider() *lastPassProvider {
+	return &lastPassProvider{}
 }
 
-// RetrieveSecret retrieves the secret from LastPass using the password field.
-func (p *lastPassProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
+// RetrieveSecret retrieves a secret from LastPass using the password field.
+func (p *lastPassProvider) RetrieveSecret(ctx context.Context, loc Location) (*Secret, error) {
+	p.id = string(loc)
+	p.clean()
+
 	cmd := execCommand(ctx, "lpass", "show", "--password", p.id)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -34,7 +35,7 @@ func (p *lastPassProvider) RetrieveSecret(ctx context.Context) (*Secret, error) 
 
 	return NewSecret([]byte(secret),
 		WithProvider(ProviderLastPass),
-		WithLocation(Location(p.id))), nil
+		WithLocation(p.id)), nil
 }
 
 // String returns the provider ID.

--- a/pkg/cli/secrets/lastpass_test.go
+++ b/pkg/cli/secrets/lastpass_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -66,14 +67,14 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			mockOutput:    "",
 			mockError:     fmt.Errorf("exit status 1"),
 			expectError:   true,
-			errorContains: "executing command",
+			errorContains: "executing lpass command",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Mock exec.Command to return our test data
-			execCommand = func(command string, args ...string) *exec.Cmd {
+			execCommand = func(ctx context.Context, command string, args ...string) *exec.Cmd {
 				cs := []string{"-test.run=TestHelperProcess", "--", command}
 				cs = append(cs, args...)
 				cmd := exec.Command(os.Args[0], cs...)
@@ -89,7 +90,7 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			}
 
 			provider := NewLastPassProvider(tt.location)
-			secret, err := provider.GetSecret()
+			secret, err := provider.RetrieveSecret()
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/cli/secrets/lastpass_test.go
+++ b/pkg/cli/secrets/lastpass_test.go
@@ -43,7 +43,6 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			expectedSecret: &Secret{
 				Value:   []byte("secretvalue"),
 				locator: &SecretLocator{Scheme: SchemeLastPass, Location: "test/entry"},
-				Data:    make(map[string]string),
 			},
 			expectError: false,
 		},
@@ -55,7 +54,6 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			expectedSecret: &Secret{
 				Value:   []byte("another-secret"),
 				locator: &SecretLocator{Scheme: SchemeLastPass, Location: "  entry with spaces  "},
-				Data:    make(map[string]string),
 			},
 			expectError: false,
 		},

--- a/pkg/cli/secrets/lastpass_test.go
+++ b/pkg/cli/secrets/lastpass_test.go
@@ -89,8 +89,8 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 				return cmd
 			}
 
-			provider := NewLastPassProvider(tt.location)
-			secret, err := provider.RetrieveSecret(t.Context())
+			provider := NewLastPassProvider()
+			secret, err := provider.RetrieveSecret(t.Context(), tt.location)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/cli/secrets/lastpass_test.go
+++ b/pkg/cli/secrets/lastpass_test.go
@@ -1,0 +1,125 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastPassProvider_GetSecret(t *testing.T) {
+	// Skip test if lpass is not installed
+	if _, err := exec.LookPath("lpass"); err != nil {
+		t.Skip("lpass is not installed, skipping LastPass provider tests")
+	}
+
+	// Create a temporary directory for gocov files
+	tmpDir, err := os.MkdirTemp("", "gocov")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir) // Clean up the temporary directory
+
+	// Mock the exec.Command function for testing
+	origExecCommand := execCommand
+	defer func() { execCommand = origExecCommand }()
+
+	tests := []struct {
+		name           string
+		location       Location
+		mockOutput     string
+		mockError      error
+		expectedSecret *Secret
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:       "successful retrieval",
+			location:   "test/entry",
+			mockOutput: "secretvalue\n",
+			mockError:  nil,
+			expectedSecret: &Secret{
+				Value:    []byte("secretvalue"),
+				Provider: ProviderLastPass,
+				Location: "test/entry",
+				Data:     make(map[string]string),
+			},
+			expectError: false,
+		},
+		{
+			name:       "with spaces in location",
+			location:   "  entry with spaces  ",
+			mockOutput: "another-secret\n",
+			mockError:  nil,
+			expectedSecret: &Secret{
+				Value:    []byte("another-secret"),
+				Provider: ProviderLastPass,
+				Location: "entry with spaces",
+				Data:     make(map[string]string),
+			},
+			expectError: false,
+		},
+		{
+			name:          "command error",
+			location:      "nonexistent",
+			mockOutput:    "",
+			mockError:     fmt.Errorf("exit status 1"),
+			expectError:   true,
+			errorContains: "executing command",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock exec.Command to return our test data
+			execCommand = func(command string, args ...string) *exec.Cmd {
+				cs := []string{"-test.run=TestHelperProcess", "--", command}
+				cs = append(cs, args...)
+				cmd := exec.Command(os.Args[0], cs...)
+
+				// Set environment variables to pass test case data to the helper process
+				cmd.Env = []string{
+					fmt.Sprintf("GOCOVERDIR=%s", tmpDir), // Set GOCOVERDIR to the temporary directory
+					"GO_WANT_HELPER_PROCESS=1",
+					fmt.Sprintf("GO_MOCK_OUTPUT=%s", tt.mockOutput),
+					fmt.Sprintf("GO_MOCK_ERROR=%v", tt.mockError != nil),
+				}
+				return cmd
+			}
+
+			provider := NewLastPassProvider(tt.location)
+			secret, err := provider.GetSecret()
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, secret)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, secret)
+				assert.Equal(t, tt.expectedSecret.Value, secret.Value)
+				assert.Equal(t, tt.expectedSecret.Provider, secret.Provider)
+				assert.Equal(t, tt.expectedSecret.Location, secret.Location)
+			}
+		})
+	}
+}
+
+// TestHelperProcess isn't a real test - it's used as a helper process for mocking exec.Command
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	// Get mock data from environment
+	mockOutput := os.Getenv("GO_MOCK_OUTPUT")
+	shouldError := os.Getenv("GO_MOCK_ERROR") == "true"
+
+	if shouldError {
+		os.Exit(1)
+	}
+
+	fmt.Fprint(os.Stdout, mockOutput)
+	os.Exit(0)
+}

--- a/pkg/cli/secrets/lastpass_test.go
+++ b/pkg/cli/secrets/lastpass_test.go
@@ -90,7 +90,7 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			}
 
 			provider := NewLastPassProvider(tt.location)
-			secret, err := provider.RetrieveSecret()
+			secret, err := provider.RetrieveSecret(t.Context())
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/cli/secrets/lastpass_test.go
+++ b/pkg/cli/secrets/lastpass_test.go
@@ -41,10 +41,9 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			mockOutput: "secretvalue\n",
 			mockError:  nil,
 			expectedSecret: &Secret{
-				Value:    []byte("secretvalue"),
-				Provider: ProviderLastPass,
-				Location: "test/entry",
-				Data:     make(map[string]string),
+				Value:   []byte("secretvalue"),
+				locator: &SecretLocator{Scheme: SchemeLastPass, Location: "test/entry"},
+				Data:    make(map[string]string),
 			},
 			expectError: false,
 		},
@@ -54,10 +53,9 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 			mockOutput: "another-secret\n",
 			mockError:  nil,
 			expectedSecret: &Secret{
-				Value:    []byte("another-secret"),
-				Provider: ProviderLastPass,
-				Location: "entry with spaces",
-				Data:     make(map[string]string),
+				Value:   []byte("another-secret"),
+				locator: &SecretLocator{Scheme: SchemeLastPass, Location: "  entry with spaces  "},
+				Data:    make(map[string]string),
 			},
 			expectError: false,
 		},
@@ -100,8 +98,8 @@ func TestLastPassProvider_GetSecret(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, secret)
 				assert.Equal(t, tt.expectedSecret.Value, secret.Value)
-				assert.Equal(t, tt.expectedSecret.Provider, secret.Provider)
-				assert.Equal(t, tt.expectedSecret.Location, secret.Location)
+				assert.Equal(t, tt.expectedSecret.GetScheme(), secret.GetScheme())
+				assert.Equal(t, tt.expectedSecret.GetLocation(), secret.GetLocation())
 			}
 		})
 	}

--- a/pkg/cli/secrets/locator.go
+++ b/pkg/cli/secrets/locator.go
@@ -8,59 +8,59 @@ import (
 // Location is a string that represents the location of a secret.
 type Location string
 
-// Identifier is a reference to a secret.
-type Identifier struct {
-	// Provider implements the provider for the identifier.
+// SecretLocator is a reference to a secret.
+type SecretLocator struct {
+	// Provider implements the provider for the secret.
 	Provider Provider
 
 	// Location is the location of the secret within the provider.
 	Location Location
 }
 
-// String returns the string representation of the identifier.
-func (i *Identifier) String() string {
+// String returns the string representation of the secret locator.
+func (sl *SecretLocator) String() string {
 	var provider string
-	if i.Provider != nil {
-		provider = i.Provider.String()
+	if sl.Provider != nil {
+		provider = sl.Provider.String()
 	}
-	return fmt.Sprintf("%s://%s", provider, i.Location)
+	return fmt.Sprintf("%s://%s", provider, sl.Location)
 }
 
 // GetSecret retrieves the secret from the provider.
 // It's a convenience method for retrieving the secret.
-func (i *Identifier) GetSecret(ctx context.Context) (*Secret, error) {
-	if i.Provider == nil {
+func (sl *SecretLocator) GetSecret(ctx context.Context) (*Secret, error) {
+	if sl.Provider == nil {
 		return nil, fmt.Errorf("missing provider")
 	}
-	return i.Provider.RetrieveSecret(ctx)
+	return sl.Provider.RetrieveSecret(ctx, sl.Location)
 }
 
 // GetSecretValue retrieves the secret value from the provider.
-func (i *Identifier) GetSecretValue(ctx context.Context) (string, error) {
-	if i.Provider == nil {
+func (sl *SecretLocator) GetSecretValue(ctx context.Context) (string, error) {
+	if sl.Provider == nil {
 		return "", fmt.Errorf("missing provider")
 	}
-	secret, err := i.Provider.RetrieveSecret(ctx)
+	secret, err := sl.Provider.RetrieveSecret(ctx, sl.Location)
 	if err != nil {
 		return "", fmt.Errorf("retrieving secret: %w", err)
 	}
 	return secret.String(), nil
 }
 
-// NewIdentifier creates a new identifier.
-func NewIdentifier(scheme string, location Location) (*Identifier, error) {
+// NewSecretLocator creates a new secret locator.
+func NewSecretLocator(scheme string, location Location) (*SecretLocator, error) {
 	provider, err := NewProvider(scheme, location)
 	if err != nil {
 		return nil, fmt.Errorf("creating provider: %w", err)
 	}
-	return &Identifier{
+	return &SecretLocator{
 		Location: location,
 		Provider: provider,
 	}, nil
 }
 
-// Validate validates the identifier.
-func (i *Identifier) Validate() error {
+// Validate validates the secret locator.
+func (i *SecretLocator) Validate() error {
 	if i.Provider == nil {
 		return fmt.Errorf("missing provider")
 	}

--- a/pkg/cli/secrets/locator_test.go
+++ b/pkg/cli/secrets/locator_test.go
@@ -55,7 +55,7 @@ func TestIdentifierString(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
-		identifier := &Identifier{Provider: provider, Location: tt.location}
+		identifier := &SecretLocator{Provider: provider, Location: tt.location}
 		assert.Equal(t, tt.expected, identifier.String())
 	}
 }
@@ -99,7 +99,7 @@ func TestNewIdentifier(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		identifier, err := NewIdentifier(tt.scheme, tt.location)
+		identifier, err := NewSecretLocator(tt.scheme, tt.location)
 
 		if tt.expectedError != nil {
 			assert.EqualError(t, err, tt.expectedError.Error())
@@ -138,7 +138,7 @@ func TestIdentifierValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		provider, _ := NewProvider(tt.scheme, tt.location)
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: provider,
 			Location: tt.location,
 		}
@@ -150,7 +150,7 @@ func TestIdentifierValidate(t *testing.T) {
 func TestIdentifierGetSecret(t *testing.T) {
 	// Test for nil provider
 	t.Run("nil provider", func(t *testing.T) {
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: nil,
 			Location: "test-location",
 		}
@@ -182,7 +182,7 @@ func TestIdentifierGetSecret(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Create identifier with file provider
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: provider,
 			Location: Location(tempFile.Name()),
 		}
@@ -202,7 +202,7 @@ func TestIdentifierGetSecret(t *testing.T) {
 		provider, err := NewProvider(ProviderFile, Location(nonExistentPath))
 		assert.NoError(t, err)
 
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: provider,
 			Location: Location(nonExistentPath),
 		}
@@ -217,7 +217,7 @@ func TestIdentifierGetSecret(t *testing.T) {
 func TestIdentifierGetSecretValue(t *testing.T) {
 	// Test for nil provider
 	t.Run("nil provider", func(t *testing.T) {
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: nil,
 			Location: "test-location",
 		}
@@ -249,7 +249,7 @@ func TestIdentifierGetSecretValue(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Create identifier with file provider
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: provider,
 			Location: Location(tempFile.Name()),
 		}
@@ -268,7 +268,7 @@ func TestIdentifierGetSecretValue(t *testing.T) {
 		provider, err := NewProvider(ProviderFile, Location(nonExistentPath))
 		assert.NoError(t, err)
 
-		identifier := &Identifier{
+		identifier := &SecretLocator{
 			Provider: provider,
 			Location: Location(nonExistentPath),
 		}

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -24,5 +24,13 @@ func parseSecretIdentifier(identifierString string) (string, Location, error) {
 		return "", "", errors.New("invalid identifier")
 	}
 
-	return m[1], Location(m[2]), nil
+	scheme := m[1]
+	location := Location(m[2])
+
+	// Check if the scheme is registered
+	if _, exists := providerRegistry[scheme]; !exists {
+		return "", "", fmt.Errorf("unknown provider scheme: %s", scheme)
+	}
+
+	return scheme, location, nil
 }

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -9,17 +9,17 @@ import (
 var secretScheme = regexp.MustCompile(`^([a-z]+):\/\/(.+)$`)
 
 // Parse parses a secret identifier string into an Identifier struct.
-func Parse(identifierString string) (*Identifier, error) {
-	p, l, err := parseSecretIdentifier(identifierString)
+func Parse(identifier string) (*Identifier, error) {
+	provider, location, err := parseSecretIdentifier(identifier)
 	if err != nil {
-		return nil, fmt.Errorf("parsing secret identifier %q: %w", identifierString, err)
+		return nil, fmt.Errorf("parsing secret identifier %q: %w", identifier, err)
 	}
 
-	return NewIdentifier(p, l)
+	return NewIdentifier(provider, location)
 }
 
-func parseSecretIdentifier(identifierString string) (string, Location, error) {
-	m := secretScheme.FindStringSubmatch(identifierString)
+func parseSecretIdentifier(identifier string) (string, Location, error) {
+	m := secretScheme.FindStringSubmatch(identifier)
 	if m == nil {
 		return "", "", errors.New("invalid identifier")
 	}

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -1,0 +1,35 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var secretScheme = regexp.MustCompile(`^([a-z]+):\/\/(.+)$`)
+
+// Parse parses a secret identifier
+// The identifier is given as an url-like string in the form of:
+// PROVIDER://LOCATION
+func Parse(id string) (*Identifier, error) {
+	p, l, err := parseSecretIdentifier(id)
+	if err != nil {
+		return nil, fmt.Errorf("parsing secret identifier %q: %w", id, err)
+	}
+
+	return NewIdentifier(p, l), nil
+}
+
+func parseSecretIdentifier(id string) (ProviderID, Location, error) {
+	m := secretScheme.FindStringSubmatch(id)
+	if m == nil {
+		return "", "", errors.New("invalid identifier")
+	}
+
+	provider, err := ParseProvider(m[1])
+	if err != nil {
+		return "", "", fmt.Errorf("parsing provider %q: %w", m[1], err)
+	}
+
+	return provider, Location(m[2]), nil
+}

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -18,13 +18,13 @@ func Parse(rawSL string) (*SecretLocator, error) {
 	return NewSecretLocator(scheme, location)
 }
 
-func parseSecretLocator(rawSL string) (string, Location, error) {
+func parseSecretLocator(rawSL string) (Scheme, Location, error) {
 	m := slRe.FindStringSubmatch(rawSL)
 	if m == nil {
 		return "", "", errors.New("invalid identifier")
 	}
 
-	scheme := m[1]
+	scheme := Scheme(m[1])
 	location := Location(m[2])
 
 	// Check if the scheme is registered

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -8,20 +8,18 @@ import (
 
 var secretScheme = regexp.MustCompile(`^([a-z]+):\/\/(.+)$`)
 
-// Parse parses a secret identifier
-// The identifier is given as an url-like string in the form of:
-// PROVIDER://LOCATION
-func Parse(id string) (*Identifier, error) {
-	p, l, err := parseSecretIdentifier(id)
+// Parse parses a secret identifier string into an Identifier struct.
+func Parse(identifierString string) (*Identifier, error) {
+	p, l, err := parseSecretIdentifier(identifierString)
 	if err != nil {
-		return nil, fmt.Errorf("parsing secret identifier %q: %w", id, err)
+		return nil, fmt.Errorf("parsing secret identifier %q: %w", identifierString, err)
 	}
 
 	return NewIdentifier(p, l), nil
 }
 
-func parseSecretIdentifier(id string) (ProviderID, Location, error) {
-	m := secretScheme.FindStringSubmatch(id)
+func parseSecretIdentifier(identifierString string) (ProviderID, Location, error) {
+	m := secretScheme.FindStringSubmatch(identifierString)
 	if m == nil {
 		return "", "", errors.New("invalid identifier")
 	}

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -15,19 +15,14 @@ func Parse(identifierString string) (*Identifier, error) {
 		return nil, fmt.Errorf("parsing secret identifier %q: %w", identifierString, err)
 	}
 
-	return NewIdentifier(p, l), nil
+	return NewIdentifier(p, l)
 }
 
-func parseSecretIdentifier(identifierString string) (ProviderID, Location, error) {
+func parseSecretIdentifier(identifierString string) (string, Location, error) {
 	m := secretScheme.FindStringSubmatch(identifierString)
 	if m == nil {
 		return "", "", errors.New("invalid identifier")
 	}
 
-	provider, err := ParseProvider(m[1])
-	if err != nil {
-		return "", "", fmt.Errorf("parsing provider %q: %w", m[1], err)
-	}
-
-	return provider, Location(m[2]), nil
+	return m[1], Location(m[2]), nil
 }

--- a/pkg/cli/secrets/parse.go
+++ b/pkg/cli/secrets/parse.go
@@ -6,20 +6,20 @@ import (
 	"regexp"
 )
 
-var secretScheme = regexp.MustCompile(`^([a-z]+):\/\/(.+)$`)
+var slRe = regexp.MustCompile(`^([a-z]+):\/\/(.+)$`)
 
-// Parse parses a secret identifier string into an Identifier struct.
-func Parse(identifier string) (*Identifier, error) {
-	provider, location, err := parseSecretIdentifier(identifier)
+// Parse parses a secret locator string into a SecretLocator struct.
+func Parse(rawSL string) (*SecretLocator, error) {
+	scheme, location, err := parseSecretLocator(rawSL)
 	if err != nil {
-		return nil, fmt.Errorf("parsing secret identifier %q: %w", identifier, err)
+		return nil, fmt.Errorf("parsing secret identifier %q: %w", rawSL, err)
 	}
 
-	return NewIdentifier(provider, location)
+	return NewSecretLocator(scheme, location)
 }
 
-func parseSecretIdentifier(identifier string) (string, Location, error) {
-	m := secretScheme.FindStringSubmatch(identifier)
+func parseSecretLocator(rawSL string) (string, Location, error) {
+	m := slRe.FindStringSubmatch(rawSL)
 	if m == nil {
 		return "", "", errors.New("invalid identifier")
 	}

--- a/pkg/cli/secrets/parse_test.go
+++ b/pkg/cli/secrets/parse_test.go
@@ -12,7 +12,7 @@ func TestParse(t *testing.T) {
 	cases := []struct {
 		desc           string
 		raw            string
-		expect         *Identifier
+		expect         *SecretLocator
 		expectProvider Provider
 		expectError    bool
 	}{
@@ -54,37 +54,37 @@ func TestParse(t *testing.T) {
 		{
 			desc: "valid uri with env provider",
 			raw:  "env://GITHUB_TOKEN",
-			expect: &Identifier{
+			expect: &SecretLocator{
 				Location: "GITHUB_TOKEN",
 			},
-			expectProvider: NewEnvProvider(Location("GITHUB_TOKEN")),
+			expectProvider: NewEnvProvider(),
 			expectError:    false,
 		},
 		{
 			desc: "valid uri with file provider",
 			raw:  "file:///path/to/secret.txt",
-			expect: &Identifier{
+			expect: &SecretLocator{
 				Location: "/path/to/secret.txt",
 			},
-			expectProvider: NewFileProvider(Location("/path/to/secret.txt")),
+			expectProvider: NewFileProvider(),
 			expectError:    false,
 		},
 		{
 			desc: "valid uri with cmd provider",
 			raw:  `cmd://gh auth token`,
-			expect: &Identifier{
+			expect: &SecretLocator{
 				Location: "gh auth token",
 			},
-			expectProvider: NewLastPassProvider(Location("gh auth token")),
+			expectProvider: NewLastPassProvider(),
 			expectError:    false,
 		},
 		{
 			desc: "valid uri with lp provider",
 			raw:  `lp://123456`,
-			expect: &Identifier{
+			expect: &SecretLocator{
 				Location: "123456",
 			},
-			expectProvider: NewLastPassProvider(Location("123456")),
+			expectProvider: NewLastPassProvider(),
 			expectError:    false,
 		},
 		{
@@ -107,7 +107,7 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, c.expect.Location, actual.Location)
 
 			if c.expect != nil {
-				scheme := secretScheme.FindStringSubmatch(c.raw)[1]
+				scheme := slRe.FindStringSubmatch(c.raw)[1]
 
 				assert.NoError(t, err)
 

--- a/pkg/cli/secrets/parse_test.go
+++ b/pkg/cli/secrets/parse_test.go
@@ -107,11 +107,11 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, c.expect.Location, actual.Location)
 
 			if c.expect != nil {
-				scheme := slRe.FindStringSubmatch(c.raw)[1]
+				scheme := Scheme(slRe.FindStringSubmatch(c.raw)[1])
 
 				assert.NoError(t, err)
 
-				expectedProvider, err := NewProvider(scheme, actual.Location)
+				expectedProvider, err := NewProvider(scheme)
 				assert.NoError(t, err)
 				assert.Equal(t, expectedProvider, actual.Provider)
 

--- a/pkg/cli/secrets/parse_test.go
+++ b/pkg/cli/secrets/parse_test.go
@@ -107,10 +107,12 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, c.expect.Location, actual.Location)
 
 			if c.expect != nil {
-				providerID, err := ParseProvider(secretScheme.FindStringSubmatch(c.raw)[1])
+				scheme := secretScheme.FindStringSubmatch(c.raw)[1]
 
 				assert.NoError(t, err)
-				expectedProvider := NewProvider(providerID, actual.Location)
+
+				expectedProvider, err := NewProvider(scheme, actual.Location)
+				assert.NoError(t, err)
 				assert.Equal(t, expectedProvider, actual.Provider)
 
 			}

--- a/pkg/cli/secrets/parse_test.go
+++ b/pkg/cli/secrets/parse_test.go
@@ -1,0 +1,119 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc           string
+		raw            string
+		expect         *Identifier
+		expectProvider Provider
+		expectError    bool
+	}{
+		{
+			desc:        "empty uri",
+			raw:         "",
+			expectError: true,
+		},
+		{
+			desc:        "invalid uri",
+			raw:         ":foo",
+			expectError: true,
+		},
+		{
+			desc:        "empty provider",
+			raw:         "://foo",
+			expectError: true,
+		},
+		{
+			desc:        "empty file",
+			raw:         "file://",
+			expectError: true,
+		},
+		{
+			desc:        "empty env",
+			raw:         "env://",
+			expectError: true,
+		},
+		{
+			desc:        "empty cmd",
+			raw:         "cmd://",
+			expectError: true,
+		},
+		{
+			desc:        "empty lp",
+			raw:         "lp://",
+			expectError: true,
+		},
+		{
+			desc: "valid uri with env provider",
+			raw:  "env://GITHUB_TOKEN",
+			expect: &Identifier{
+				Location: "GITHUB_TOKEN",
+			},
+			expectProvider: NewEnvProvider(Location("GITHUB_TOKEN")),
+			expectError:    false,
+		},
+		{
+			desc: "valid uri with file provider",
+			raw:  "file:///path/to/secret.txt",
+			expect: &Identifier{
+				Location: "/path/to/secret.txt",
+			},
+			expectProvider: NewFileProvider(Location("/path/to/secret.txt")),
+			expectError:    false,
+		},
+		{
+			desc: "valid uri with cmd provider",
+			raw:  `cmd://gh auth token`,
+			expect: &Identifier{
+				Location: "gh auth token",
+			},
+			expectProvider: NewLastPassProvider(Location("gh auth token")),
+			expectError:    false,
+		},
+		{
+			desc: "valid uri with lp provider",
+			raw:  `lp://123456`,
+			expect: &Identifier{
+				Location: "123456",
+			},
+			expectProvider: NewLastPassProvider(Location("123456")),
+			expectError:    false,
+		},
+		{
+			desc:        "valid uri with unknown provider",
+			raw:         "foo://bar",
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			actual, err := Parse(c.raw)
+
+			if c.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, c.expect.Location, actual.Location)
+
+			if c.expect != nil {
+				providerID, err := ParseProvider(secretScheme.FindStringSubmatch(c.raw)[1])
+
+				assert.NoError(t, err)
+				expectedProvider := NewProvider(providerID, actual.Location)
+				assert.Equal(t, expectedProvider, actual.Provider)
+
+			}
+		})
+	}
+}

--- a/pkg/cli/secrets/provider.go
+++ b/pkg/cli/secrets/provider.go
@@ -1,6 +1,9 @@
 package secrets
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type ProviderID string
 
@@ -31,7 +34,7 @@ func ParseProvider(v string) (ProviderID, error) {
 type Provider interface {
 	// RetrieveSecret retrieves the secret from the provider.
 	// It does the actual work of retrieving the secret..
-	RetrieveSecret() (*Secret, error)
+	RetrieveSecret(context.Context) (*Secret, error)
 
 	// String returns the string representation of the provider.
 	String() string

--- a/pkg/cli/secrets/provider.go
+++ b/pkg/cli/secrets/provider.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ProviderUnknown = "unknown"
+	SchemeUnknown = "unknown"
 )
 
 // Provider is an interface that provides a secret.
@@ -15,44 +15,44 @@ type Provider interface {
 	// It does the actual work of retrieving the secret..
 	RetrieveSecret(context.Context, Location) (*Secret, error)
 
-	// String returns the string representation of the provider.
-	String() string
+	// Scheme returns the scheme for the provider.
+	Scheme() Scheme
 }
 
 // Factory function type for creating providers
-type ProviderFactory func(location Location) Provider
+type ProviderFactory func() Provider
 
 // Registry to store provider factories
-var providerRegistry = make(map[string]ProviderFactory)
+var providerRegistry = make(map[Scheme]ProviderFactory)
 
 // Register a new provider type
-func RegisterProvider(scheme string, factory ProviderFactory) {
+func RegisterProvider(scheme Scheme, factory ProviderFactory) {
 	providerRegistry[scheme] = factory
 }
 
 // NewProvider creates a new provider instance
-func NewProvider(scheme string, location Location) (Provider, error) {
+func NewProvider(scheme Scheme) (Provider, error) {
 	factory, exists := providerRegistry[scheme]
 	if !exists {
 		return nil, fmt.Errorf("unknown provider scheme: %s", scheme)
 	}
-	return factory(location), nil
+	return factory(), nil
 }
 
 func init() {
-	RegisterProvider("file", func(_ Location) Provider {
+	RegisterProvider(SchemeFile, func() Provider {
 		return NewFileProvider()
 	})
 
-	RegisterProvider("env", func(_ Location) Provider {
+	RegisterProvider(SchemeEnv, func() Provider {
 		return NewEnvProvider()
 	})
 
-	RegisterProvider("cmd", func(_ Location) Provider {
+	RegisterProvider(SchemeCmd, func() Provider {
 		return NewCmdProvider()
 	})
 
-	RegisterProvider("lp", func(_ Location) Provider {
+	RegisterProvider(SchemeLastPass, func() Provider {
 		return NewLastPassProvider()
 	})
 }

--- a/pkg/cli/secrets/provider.go
+++ b/pkg/cli/secrets/provider.go
@@ -29,8 +29,9 @@ func ParseProvider(v string) (ProviderID, error) {
 
 // Provider is an interface that provides a secret.
 type Provider interface {
-	// GetSecret retrieves the secret from the provider.
-	GetSecret() (*Secret, error)
+	// RetrieveSecret retrieves the secret from the provider.
+	// It does the actual work of retrieving the secret..
+	RetrieveSecret() (*Secret, error)
 
 	// String returns the string representation of the provider.
 	String() string

--- a/pkg/cli/secrets/provider.go
+++ b/pkg/cli/secrets/provider.go
@@ -11,9 +11,9 @@ const (
 
 // Provider is an interface that provides a secret.
 type Provider interface {
-	// RetrieveSecret retrieves the secret from the provider.
+	// RetrieveSecret retrieves a secret from the provider.
 	// It does the actual work of retrieving the secret..
-	RetrieveSecret(context.Context) (*Secret, error)
+	RetrieveSecret(context.Context, Location) (*Secret, error)
 
 	// String returns the string representation of the provider.
 	String() string
@@ -30,6 +30,7 @@ func RegisterProvider(scheme string, factory ProviderFactory) {
 	providerRegistry[scheme] = factory
 }
 
+// NewProvider creates a new provider instance
 func NewProvider(scheme string, location Location) (Provider, error) {
 	factory, exists := providerRegistry[scheme]
 	if !exists {
@@ -39,19 +40,19 @@ func NewProvider(scheme string, location Location) (Provider, error) {
 }
 
 func init() {
-	RegisterProvider("file", func(location Location) Provider {
-		return NewFileProvider(location)
+	RegisterProvider("file", func(_ Location) Provider {
+		return NewFileProvider()
 	})
 
-	RegisterProvider("env", func(location Location) Provider {
-		return NewEnvProvider(location)
+	RegisterProvider("env", func(_ Location) Provider {
+		return NewEnvProvider()
 	})
 
-	RegisterProvider("cmd", func(location Location) Provider {
-		return NewCmdProvider(location)
+	RegisterProvider("cmd", func(_ Location) Provider {
+		return NewCmdProvider()
 	})
 
-	RegisterProvider("lp", func(location Location) Provider {
-		return NewLastPassProvider(location)
+	RegisterProvider("lp", func(_ Location) Provider {
+		return NewLastPassProvider()
 	})
 }

--- a/pkg/cli/secrets/provider.go
+++ b/pkg/cli/secrets/provider.go
@@ -1,0 +1,53 @@
+package secrets
+
+import "fmt"
+
+type ProviderID string
+
+const (
+	ProviderFile     ProviderID = "file"
+	ProviderEnv      ProviderID = "env"
+	ProviderCmd      ProviderID = "cmd"
+	ProviderLastPass ProviderID = "lp"
+	ProviderUnknown  ProviderID = "unknown"
+)
+
+// String returns the string representation of the provider.
+func (p ProviderID) String() string {
+	return string(p)
+}
+
+// ParseProvider parses a provider from a string.
+func ParseProvider(v string) (ProviderID, error) {
+	switch ProviderID(v) {
+	case ProviderFile, ProviderEnv, ProviderCmd, ProviderLastPass:
+		return ProviderID(v), nil
+	default:
+		return "", fmt.Errorf("unknown provider: %s", v)
+	}
+}
+
+// Provider is an interface that provides a secret.
+type Provider interface {
+	// GetSecret retrieves the secret from the provider.
+	GetSecret() (*Secret, error)
+
+	// String returns the string representation of the provider.
+	String() string
+}
+
+// NewProvider creates a new provider.
+func NewProvider(id ProviderID, location Location) Provider {
+	switch id {
+	case ProviderFile:
+		return NewFileProvider(location)
+	case ProviderEnv:
+		return NewEnvProvider(location)
+	case ProviderCmd:
+		return NewCmdProvider(location)
+	case ProviderLastPass:
+		return NewLastPassProvider(location)
+	default:
+		return nil
+	}
+}

--- a/pkg/cli/secrets/provider_test.go
+++ b/pkg/cli/secrets/provider_test.go
@@ -1,76 +1,112 @@
 package secrets
 
 import (
+	"context"
+	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseProvider(t *testing.T) {
+func TestNewProvider(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected ProviderID
-		wantErr  bool
+		scheme        string
+		expected      Provider
+		location      Location
+		expectedError error
 	}{
-		{"file", ProviderFile, false},
-		{"env", ProviderEnv, false},
-		{"cmd", ProviderCmd, false},
-		{"lp", ProviderLastPass, false},
-		{"unknown", ProviderUnknown, true},
-		{"", ProviderUnknown, true},
+		{
+			scheme:        ProviderEnv,
+			expected:      NewEnvProvider(Location("MY_SECRET")),
+			location:      Location("MY_SECRET"),
+			expectedError: nil,
+		},
+		{
+			scheme:        ProviderFile,
+			expected:      NewFileProvider(Location("/path/to/secret.txt")),
+			location:      Location("/path/to/secret.txt"),
+			expectedError: nil,
+		},
+		{
+			scheme:        ProviderCmd,
+			expected:      NewCmdProvider(Location("get secret")),
+			location:      Location("get secret"),
+			expectedError: nil,
+		},
+		{
+			scheme:        ProviderLastPass,
+			expected:      NewLastPassProvider(Location("123456")),
+			location:      Location("123456"),
+			expectedError: nil,
+		},
+		{
+			scheme:        ProviderUnknown,
+			expected:      nil,
+			location:      Location(""),
+			expectedError: fmt.Errorf("unknown provider scheme: %s", ProviderUnknown),
+		},
 	}
-
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got, err := ParseProvider(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Equal(t, "", got.String())
-				return
+		t.Run(tt.scheme, func(t *testing.T) {
+			got, err := NewProvider(tt.scheme, tt.location)
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
 			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, got)
+			assert.IsType(t, tt.expected, got)
 		})
 	}
 }
 
-func TestNewProvider(t *testing.T) {
-	tests := []struct {
-		id       ProviderID
-		expected Provider
-		location Location
-	}{
-		{
-			id:       ProviderEnv,
-			expected: NewEnvProvider(Location("MY_SECRET")),
-			location: Location("MY_SECRET"),
-		},
-		{
-			id:       ProviderFile,
-			expected: NewFileProvider(Location("/path/to/secret.txt")),
-			location: Location("/path/to/secret.txt"),
-		},
-		{
-			id:       ProviderCmd,
-			expected: NewCmdProvider(Location("get secret")),
-			location: Location("get secret"),
-		},
-		{
-			id:       ProviderLastPass,
-			expected: NewLastPassProvider(Location("123456")),
-			location: Location("123456"),
-		},
-		{
-			id:       ProviderUnknown,
-			expected: nil,
-			location: Location(""),
-		},
+func TestRegisterProvider(t *testing.T) {
+	// Save the original registry to restore it later
+	originalRegistry := make(map[string]ProviderFactory)
+	maps.Copy(originalRegistry, providerRegistry)
+
+	// Clear the registry for this test
+	for k := range providerRegistry {
+		delete(providerRegistry, k)
 	}
-	for _, tt := range tests {
-		t.Run(tt.id.String(), func(t *testing.T) {
-			got := NewProvider(tt.id, tt.location)
-			assert.IsType(t, tt.expected, got)
-		})
+
+	// Verify registry is empty
+	assert.Empty(t, providerRegistry)
+
+	mockFactory := func(location Location) Provider {
+		return &mockProvider{loc: string(location)}
 	}
+
+	// Register the mock provider
+	RegisterProvider("mock", mockFactory)
+
+	// Verify the provider was registered
+	assert.Contains(t, providerRegistry, "mock")
+	assert.NotNil(t, providerRegistry["mock"])
+
+	// Create a provider using the factory
+	provider, err := NewProvider("mock", Location("test"))
+	assert.NoError(t, err)
+	assert.IsType(t, &mockProvider{}, provider)
+	assert.Equal(t, "test", provider.(*mockProvider).loc)
+
+	// Restore the original registry
+	providerRegistry = originalRegistry
+}
+
+// Create a mock provider
+type mockProvider struct {
+	loc string
+}
+
+func (p *mockProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
+	p.loc = "test"
+	secret := "test"
+	return NewSecret([]byte(secret),
+		WithProvider(ProviderCmd),
+		WithLocation(Location(p.loc))), nil
+}
+
+func (p *mockProvider) String() string {
+	return "mock"
 }

--- a/pkg/cli/secrets/provider_test.go
+++ b/pkg/cli/secrets/provider_test.go
@@ -18,25 +18,25 @@ func TestNewProvider(t *testing.T) {
 	}{
 		{
 			scheme:        ProviderEnv,
-			expected:      NewEnvProvider(Location("MY_SECRET")),
+			expected:      NewEnvProvider(),
 			location:      Location("MY_SECRET"),
 			expectedError: nil,
 		},
 		{
 			scheme:        ProviderFile,
-			expected:      NewFileProvider(Location("/path/to/secret.txt")),
+			expected:      NewFileProvider(),
 			location:      Location("/path/to/secret.txt"),
 			expectedError: nil,
 		},
 		{
 			scheme:        ProviderCmd,
-			expected:      NewCmdProvider(Location("get secret")),
+			expected:      NewCmdProvider(),
 			location:      Location("get secret"),
 			expectedError: nil,
 		},
 		{
 			scheme:        ProviderLastPass,
-			expected:      NewLastPassProvider(Location("123456")),
+			expected:      NewLastPassProvider(),
 			location:      Location("123456"),
 			expectedError: nil,
 		},
@@ -73,8 +73,8 @@ func TestRegisterProvider(t *testing.T) {
 	// Verify registry is empty
 	assert.Empty(t, providerRegistry)
 
-	mockFactory := func(location Location) Provider {
-		return &mockProvider{loc: string(location)}
+	mockFactory := func(loc Location) Provider {
+		return &mockProvider{loc: string(loc)}
 	}
 
 	// Register the mock provider
@@ -99,12 +99,12 @@ type mockProvider struct {
 	loc string
 }
 
-func (p *mockProvider) RetrieveSecret(ctx context.Context) (*Secret, error) {
+func (p *mockProvider) RetrieveSecret(ctx context.Context, loc Location) (*Secret, error) {
 	p.loc = "test"
 	secret := "test"
 	return NewSecret([]byte(secret),
 		WithProvider(ProviderCmd),
-		WithLocation(Location(p.loc))), nil
+		WithLocation(p.loc)), nil
 }
 
 func (p *mockProvider) String() string {

--- a/pkg/cli/secrets/provider_test.go
+++ b/pkg/cli/secrets/provider_test.go
@@ -1,0 +1,76 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseProvider(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected ProviderID
+		wantErr  bool
+	}{
+		{"file", ProviderFile, false},
+		{"env", ProviderEnv, false},
+		{"cmd", ProviderCmd, false},
+		{"lp", ProviderLastPass, false},
+		{"unknown", ProviderUnknown, true},
+		{"", ProviderUnknown, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseProvider(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, "", got.String())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		id       ProviderID
+		expected Provider
+		location Location
+	}{
+		{
+			id:       ProviderEnv,
+			expected: NewEnvProvider(Location("MY_SECRET")),
+			location: Location("MY_SECRET"),
+		},
+		{
+			id:       ProviderFile,
+			expected: NewFileProvider(Location("/path/to/secret.txt")),
+			location: Location("/path/to/secret.txt"),
+		},
+		{
+			id:       ProviderCmd,
+			expected: NewCmdProvider(Location("get secret")),
+			location: Location("get secret"),
+		},
+		{
+			id:       ProviderLastPass,
+			expected: NewLastPassProvider(Location("123456")),
+			location: Location("123456"),
+		},
+		{
+			id:       ProviderUnknown,
+			expected: nil,
+			location: Location(""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			got := NewProvider(tt.id, tt.location)
+			assert.IsType(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/cli/secrets/secret.go
+++ b/pkg/cli/secrets/secret.go
@@ -1,7 +1,5 @@
 package secrets
 
-import "sync"
-
 // Secret stores a secret value along with some data about the secret.
 type Secret struct {
 	// Value is the secret value.
@@ -9,10 +7,6 @@ type Secret struct {
 
 	// locator is a reference to the secret locator this this secret
 	locator *SecretLocator
-
-	// Data is additional data about the secret.
-	dataMu sync.Mutex
-	Data   map[string]string
 }
 
 // String returns a string representation of the secret.
@@ -29,13 +23,6 @@ func (s *Secret) DestroyValue() {
 		s.Value[i] = 0
 	}
 	s.Value = nil
-}
-
-// SetData sets a key-value pair in the secret's data.
-func (s *Secret) SetData(key, value string) {
-	s.dataMu.Lock()
-	defer s.dataMu.Unlock()
-	s.Data[key] = value
 }
 
 // GetScheme returns the scheme of the secret locator.
@@ -61,7 +48,6 @@ type SecretOption func(*Secret)
 func NewSecret(value []byte, opts ...SecretOption) *Secret {
 	s := &Secret{
 		Value: value,
-		Data:  make(map[string]string),
 	}
 
 	for _, opt := range opts {

--- a/pkg/cli/secrets/secret.go
+++ b/pkg/cli/secrets/secret.go
@@ -6,7 +6,7 @@ type Secret struct {
 	Value []byte
 
 	// Provider is the type of secret provider.
-	Provider ProviderID
+	Provider string
 
 	// Location is the location of the secret within the provider.
 	Location Location
@@ -51,9 +51,9 @@ func NewSecret(value []byte, opts ...SecretOption) *Secret {
 }
 
 // WithProvider sets the provider of the secret.
-func WithProvider(provider ProviderID) SecretOption {
+func WithProvider(scheme string) SecretOption {
 	return func(s *Secret) {
-		s.Provider = provider
+		s.Provider = scheme
 	}
 }
 

--- a/pkg/cli/secrets/secret.go
+++ b/pkg/cli/secrets/secret.go
@@ -9,7 +9,7 @@ type Secret struct {
 	Provider string
 
 	// Location is the location of the secret within the provider.
-	Location Location
+	Location string
 
 	// Data is additional data about the secret.
 	Data map[string]string
@@ -58,7 +58,7 @@ func WithProvider(scheme string) SecretOption {
 }
 
 // WithLocation sets the location of the secret.
-func WithLocation(location Location) SecretOption {
+func WithLocation(location string) SecretOption {
 	return func(s *Secret) {
 		s.Location = location
 	}

--- a/pkg/cli/secrets/secret.go
+++ b/pkg/cli/secrets/secret.go
@@ -21,13 +21,14 @@ func (s *Secret) String() string {
 }
 
 // DestroySecret destroys the secret value.
-func (s *Secret) DestroySecret() {
-	if s.Value != nil {
-		for i := range s.Value {
-			s.Value[i] = 0
-		}
-		s.Value = nil
+func (s *Secret) DestroyValue() {
+	if s.Value == nil {
+		return
 	}
+	for i := range s.Value {
+		s.Value[i] = 0
+	}
+	s.Value = nil
 }
 
 // SecretOption is a function that configures a secret.

--- a/pkg/cli/secrets/secret.go
+++ b/pkg/cli/secrets/secret.go
@@ -20,6 +20,16 @@ func (s *Secret) String() string {
 	return string(s.Value)
 }
 
+// DestroySecret destroys the secret value.
+func (s *Secret) DestroySecret() {
+	if s.Value != nil {
+		for i := range s.Value {
+			s.Value[i] = 0
+		}
+		s.Value = nil
+	}
+}
+
 // SecretOption is a function that configures a secret.
 type SecretOption func(*Secret)
 

--- a/pkg/cli/secrets/secret.go
+++ b/pkg/cli/secrets/secret.go
@@ -1,0 +1,54 @@
+package secrets
+
+// Secret stores a secret value along with some data about the secret.
+type Secret struct {
+	// Value is the secret value.
+	Value []byte
+
+	// Provider is the type of secret provider.
+	Provider ProviderID
+
+	// Location is the location of the secret within the provider.
+	Location Location
+
+	// Data is additional data about the secret.
+	Data map[string]string
+}
+
+// String returns a string representation of the secret.
+func (s *Secret) String() string {
+	return string(s.Value)
+}
+
+// SecretOption is a function that configures a secret.
+type SecretOption func(*Secret)
+
+// NewSecret creates a new secret.
+func NewSecret(value []byte, opts ...SecretOption) *Secret {
+	s := &Secret{
+		Value:    value,
+		Provider: ProviderUnknown,
+		Location: "",
+		Data:     make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// WithProvider sets the provider of the secret.
+func WithProvider(provider ProviderID) SecretOption {
+	return func(s *Secret) {
+		s.Provider = provider
+	}
+}
+
+// WithLocation sets the location of the secret.
+func WithLocation(location Location) SecretOption {
+	return func(s *Secret) {
+		s.Location = location
+	}
+}

--- a/pkg/cli/secrets/secret_test.go
+++ b/pkg/cli/secrets/secret_test.go
@@ -1,0 +1,89 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   []byte
+		opts    []SecretOption
+		want    *Secret
+		wantErr bool
+	}{
+		{
+			name:  "NoOptions",
+			value: []byte("secret"),
+			want: &Secret{
+				Value:    []byte("secret"),
+				Provider: ProviderUnknown,
+				Location: "",
+				Data:     map[string]string{},
+			},
+		},
+		{
+			name:  "WithProvider",
+			value: []byte("secret"),
+			opts: []SecretOption{
+				WithProvider(ProviderEnv),
+			},
+			want: &Secret{
+				Value:    []byte("secret"),
+				Provider: ProviderEnv,
+				Location: "",
+				Data:     map[string]string{},
+			},
+		},
+		{
+			name:  "WithLocation",
+			value: []byte("secret"),
+			opts: []SecretOption{
+				WithLocation("path/to/secret"),
+			},
+			want: &Secret{
+				Value:    []byte("secret"),
+				Provider: ProviderUnknown,
+				Location: "path/to/secret",
+				Data:     map[string]string{},
+			},
+		},
+		{
+			name:  "WithProviderAndLocation",
+			value: []byte("secret"),
+			opts: []SecretOption{
+				WithProvider(ProviderFile),
+				WithLocation("path/to/secret"),
+			},
+			want: &Secret{
+				Value:    []byte("secret"),
+				Provider: ProviderFile,
+				Location: "path/to/secret",
+				Data:     map[string]string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewSecret(tt.value, tt.opts...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWithProvider(t *testing.T) {
+	s := &Secret{}
+	WithProvider(ProviderEnv)(s)
+
+	assert.Equal(t, ProviderEnv, s.Provider)
+}
+
+func TestWithLocation(t *testing.T) {
+	s := &Secret{}
+	WithLocation("path/to/secret")(s)
+
+	assert.Equal(t, Location("path/to/secret"), s.Location)
+}

--- a/pkg/cli/secrets/secret_test.go
+++ b/pkg/cli/secrets/secret_test.go
@@ -41,31 +41,6 @@ func TestSecret_DestroyValue(t *testing.T) {
 	}
 }
 
-func TestSecret_SetData(t *testing.T) {
-	tests := []struct {
-		name         string
-		key          string
-		val          string
-		extectedData map[string]string
-	}{
-		{
-			name: "with data",
-			key:  "test",
-			val:  "data",
-			extectedData: map[string]string{
-				"test": "data",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := NewSecret([]byte("test"))
-			s.SetData(tt.key, tt.val)
-			assert.Equal(t, tt.extectedData, s.Data)
-		})
-	}
-}
-
 func TestSecret_GetScheme(t *testing.T) {
 	sl, _ := NewSecretLocator("env", "TEST")
 	s := NewSecret([]byte("test"), WithLocator(sl))

--- a/pkg/cli/secrets/secrets.go
+++ b/pkg/cli/secrets/secrets.go
@@ -1,0 +1,67 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+var DefaultTimeout = 10 * time.Second
+
+// GetSecret retrieves a secret using a provider.
+// It sets a default timeout for the operation. See DefaultTimeout.
+// The identifier is given as an url-like string in the form of:
+// PROVIDER://LOCATION
+func GetSecret(identifierString string) (*Secret, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	return fetchSecretWithContext(ctx, identifierString)
+}
+
+// GetSecretWithContext retrieves a secret using a provider.
+// It uses the provided context.
+// The identifier is given as an url-like string in the form of:
+// PROVIDER://LOCATION
+func GetSecretWithContext(ctx context.Context, identifierString string) (*Secret, error) {
+	return fetchSecretWithContext(ctx, identifierString)
+}
+
+// GetSecretValue retrieves the value of a secret using a provider.
+// It sets a default timeout for the operation. See DefaultTimeout.
+// The identifier is given as an url-like string in the form of:
+// PROVIDER://LOCATION
+func GetSecretValue(identifierString string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	return fetchSecretValueWithContext(ctx, identifierString)
+}
+
+// GetSecretValueWithContext retrieves the value of a secret using a provider.
+// It uses the provided context.
+// The identifier is given as an url-like string in the form of:
+// PROVIDER://LOCATION
+func GetSecretValueWithContext(ctx context.Context, identifierString string) (string, error) {
+	return fetchSecretValueWithContext(ctx, identifierString)
+}
+
+func fetchSecretWithContext(ctx context.Context, identifierString string) (*Secret, error) {
+	identifier, err := Parse(identifierString)
+	if err != nil {
+		return nil, err
+	}
+	return identifier.Provider.RetrieveSecret(ctx)
+}
+
+func fetchSecretValueWithContext(ctx context.Context, identifierString string) (string, error) {
+	identifier, err := Parse(identifierString)
+	if err != nil {
+		return "", err
+	}
+	secret, err := identifier.Provider.RetrieveSecret(ctx)
+	if err != nil {
+		return "", fmt.Errorf("retrieving secret: %w", err)
+	}
+	return secret.String(), nil
+}

--- a/pkg/cli/secrets/secrets.go
+++ b/pkg/cli/secrets/secrets.go
@@ -8,58 +8,52 @@ import (
 
 var DefaultTimeout = 10 * time.Second
 
-// GetSecret retrieves a secret using a provider.
+// GetSecret retrieves a secret.
+// The secret locator is in the form: provider://location
 // It sets a default timeout for the operation. See DefaultTimeout.
-// The identifier is given as an url-like string in the form of:
-// PROVIDER://LOCATION
-func GetSecret(identifierString string) (*Secret, error) {
+func GetSecret(rawSL string) (*Secret, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
 
-	return fetchSecretWithContext(ctx, identifierString)
+	return fetchSecretWithContext(ctx, rawSL)
 }
 
-// GetSecretWithContext retrieves a secret using a provider.
-// It uses the provided context.
-// The identifier is given as an url-like string in the form of:
-// PROVIDER://LOCATION
-func GetSecretWithContext(ctx context.Context, identifierString string) (*Secret, error) {
-	return fetchSecretWithContext(ctx, identifierString)
+// GetSecretWithContext retrieves a secret.
+// The secret locator is in the form: provider://location
+func GetSecretWithContext(ctx context.Context, rawSL string) (*Secret, error) {
+	return fetchSecretWithContext(ctx, rawSL)
 }
 
-// GetSecretValue retrieves the value of a secret using a provider.
+// GetSecretValue retrieves the value of a secret.
+// The secret locator is in the form: provider://location
 // It sets a default timeout for the operation. See DefaultTimeout.
-// The identifier is given as an url-like string in the form of:
-// PROVIDER://LOCATION
-func GetSecretValue(identifierString string) (string, error) {
+func GetSecretValue(rawSL string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
 
-	return fetchSecretValueWithContext(ctx, identifierString)
+	return fetchSecretValueWithContext(ctx, rawSL)
 }
 
-// GetSecretValueWithContext retrieves the value of a secret using a provider.
-// It uses the provided context.
-// The identifier is given as an url-like string in the form of:
-// PROVIDER://LOCATION
-func GetSecretValueWithContext(ctx context.Context, identifierString string) (string, error) {
-	return fetchSecretValueWithContext(ctx, identifierString)
+// GetSecretValueWithContext retrieves the value of a secret.
+// The secret locator is in the form: provider://location
+func GetSecretValueWithContext(ctx context.Context, rawSL string) (string, error) {
+	return fetchSecretValueWithContext(ctx, rawSL)
 }
 
-func fetchSecretWithContext(ctx context.Context, identifierString string) (*Secret, error) {
-	identifier, err := Parse(identifierString)
+func fetchSecretWithContext(ctx context.Context, rawSL string) (*Secret, error) {
+	sl, err := Parse(rawSL)
 	if err != nil {
 		return nil, err
 	}
-	return identifier.Provider.RetrieveSecret(ctx)
+	return sl.Provider.RetrieveSecret(ctx, sl.Location)
 }
 
-func fetchSecretValueWithContext(ctx context.Context, identifierString string) (string, error) {
-	identifier, err := Parse(identifierString)
+func fetchSecretValueWithContext(ctx context.Context, rawSL string) (string, error) {
+	sl, err := Parse(rawSL)
 	if err != nil {
 		return "", err
 	}
-	secret, err := identifier.Provider.RetrieveSecret(ctx)
+	secret, err := sl.Provider.RetrieveSecret(ctx, sl.Location)
 	if err != nil {
 		return "", fmt.Errorf("retrieving secret: %w", err)
 	}

--- a/pkg/cli/secrets/secrets_test.go
+++ b/pkg/cli/secrets/secrets_test.go
@@ -79,6 +79,12 @@ func TestGetSecretValue(t *testing.T) {
 			env:           map[string]string{"MY_SECRET": "secret-value"},
 			expectedValue: "secret-value",
 		},
+		{
+			name:          "env provider",
+			identifier:    "env://MISSING_ENV_VARIABLE",
+			expectedError: "missing environment variable",
+			expectedValue: "secret-value",
+		},
 	}
 
 	for _, tt := range tests {
@@ -87,6 +93,99 @@ func TestGetSecretValue(t *testing.T) {
 				_ = os.Setenv(k, v)
 			}
 			value, err := GetSecretValue(tt.identifier)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Equal(t, "", value)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, value)
+			}
+		})
+	}
+}
+
+func TestGetSecretWithContext(t *testing.T) {
+	tests := []struct {
+		name          string
+		identifier    string
+		expectedError string
+		env           map[string]string
+	}{
+		{
+			name:          "invalid identifier",
+			identifier:    "invalid-format",
+			expectedError: "invalid identifier",
+			env:           nil,
+		},
+		{
+			name:          "unknown provider",
+			identifier:    "unknown://location",
+			expectedError: "unknown provider",
+			env:           nil,
+		},
+		{
+			name:          "env provider",
+			identifier:    "env://MY_SECRET",
+			expectedError: "",
+			env:           map[string]string{"MY_SECRET": "secret-value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				_ = os.Setenv(k, v)
+			}
+			secret, err := GetSecretWithContext(t.Context(), tt.identifier)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, secret)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetSecretValueWithContext(t *testing.T) {
+	tests := []struct {
+		name          string
+		identifier    string
+		expectedError string
+		expectedValue string
+		env           map[string]string
+	}{
+		{
+			name:          "invalid identifier",
+			identifier:    "invalid-format",
+			expectedError: "invalid identifier",
+			expectedValue: "",
+		},
+		{
+			name:          "unknown provider",
+			identifier:    "unknown://location",
+			expectedError: "unknown provider",
+			expectedValue: "",
+		},
+		{
+			name:          "env provider",
+			identifier:    "env://MY_SECRET",
+			expectedError: "",
+			env:           map[string]string{"MY_SECRET": "secret-value"},
+			expectedValue: "secret-value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				_ = os.Setenv(k, v)
+			}
+			value, err := GetSecretValueWithContext(t.Context(), tt.identifier)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)

--- a/pkg/cli/secrets/secrets_test.go
+++ b/pkg/cli/secrets/secrets_test.go
@@ -1,0 +1,101 @@
+package secrets
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSecret(t *testing.T) {
+	tests := []struct {
+		name          string
+		identifier    string
+		expectedError string
+		env           map[string]string
+	}{
+		{
+			name:          "invalid identifier",
+			identifier:    "invalid-format",
+			expectedError: "invalid identifier",
+			env:           nil,
+		},
+		{
+			name:          "unknown provider",
+			identifier:    "unknown://location",
+			expectedError: "unknown provider",
+			env:           nil,
+		},
+		{
+			name:          "env provider",
+			identifier:    "env://MY_SECRET",
+			expectedError: "",
+			env:           map[string]string{"MY_SECRET": "secret-value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				_ = os.Setenv(k, v)
+			}
+			secret, err := GetSecret(tt.identifier)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, secret)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetSecretValue(t *testing.T) {
+	tests := []struct {
+		name          string
+		identifier    string
+		expectedError string
+		expectedValue string
+		env           map[string]string
+	}{
+		{
+			name:          "invalid identifier",
+			identifier:    "invalid-format",
+			expectedError: "invalid identifier",
+			expectedValue: "",
+		},
+		{
+			name:          "unknown provider",
+			identifier:    "unknown://location",
+			expectedError: "unknown provider",
+			expectedValue: "",
+		},
+		{
+			name:          "env provider",
+			identifier:    "env://MY_SECRET",
+			expectedError: "",
+			env:           map[string]string{"MY_SECRET": "secret-value"},
+			expectedValue: "secret-value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				_ = os.Setenv(k, v)
+			}
+			value, err := GetSecretValue(tt.identifier)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Equal(t, "", value)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
It's the implementation of what we talked about in https://github.com/neticdk/scrolls/pull/37

This is for parsing a secrets scheme like the one below and getting that secret depending on the provider:

```bash
--token env://GITHUB_TOKEN
--token file:///path/to/token.txt
--token cmd://"gh auth token"
--token lp://1234567  # last pass
```

To whoever is reviewing it might help to start with secrets.go, then identifier.go, then provider.go, then secret.go and finally the providers.