### PR TITLE
feat: additional slice operations

### DIFF
--- a/pkg/slice/fold.go
+++ b/pkg/slice/fold.go
@@ -1,0 +1,25 @@
+package slice
+
+// Fold applies a function to each element of the slice,
+// storing the result in an accumulator.
+// It applies the function from left to right.
+func Fold[T any](acc T, data []T, f func(T, T) T) T {
+	res := acc
+	for _, e := range data {
+		res = f(res, e)
+	}
+
+	return res
+}
+
+// Fold applies a function to each element of the slice,
+// storing the result in an accumulator.
+// It applies the function from right to left.
+func FoldR[T any](acc T, data []T, f func(T, T) T) T {
+	res := acc
+	for i := len(data) - 1; i >= 0; i-- {
+		res = f(res, data[i])
+	}
+
+	return res
+}

--- a/pkg/slice/fold.go
+++ b/pkg/slice/fold.go
@@ -3,7 +3,7 @@ package slice
 // Fold applies a function to each element of the slice,
 // storing the result in an accumulator.
 // It applies the function from left to right.
-func Fold[T any](acc T, data []T, f func(T, T) T) T {
+func Fold[T any, S any](acc T, data []S, f func(T, S) T) T {
 	res := acc
 	for _, e := range data {
 		res = f(res, e)
@@ -15,7 +15,7 @@ func Fold[T any](acc T, data []T, f func(T, T) T) T {
 // Fold applies a function to each element of the slice,
 // storing the result in an accumulator.
 // It applies the function from right to left.
-func FoldR[T any](acc T, data []T, f func(T, T) T) T {
+func FoldR[T any, S any](acc T, data []S, f func(T, S) T) T {
 	res := acc
 	for i := len(data) - 1; i >= 0; i-- {
 		res = f(res, data[i])

--- a/pkg/slice/fold.go
+++ b/pkg/slice/fold.go
@@ -3,7 +3,7 @@ package slice
 // Fold applies a function to each element of the slice.
 // storing the result in an accumulator.
 // It applies the function from left to right.
-func Fold[T any, S any](acc T, data []S, f func(T, S) T) T {
+func Fold[T, S any](acc T, data []S, f func(T, S) T) T {
 	res := acc
 	for _, e := range data {
 		res = f(res, e)
@@ -15,7 +15,7 @@ func Fold[T any, S any](acc T, data []S, f func(T, S) T) T {
 // FoldR applies a function to each element of the slice.
 // storing the result in an accumulator.
 // It applies the function from right to left.
-func FoldR[T any, S any](acc T, data []S, f func(T, S) T) T {
+func FoldR[T, S any](acc T, data []S, f func(T, S) T) T {
 	res := acc
 	for i := len(data) - 1; i >= 0; i-- {
 		res = f(res, data[i])

--- a/pkg/slice/fold_test.go
+++ b/pkg/slice/fold_test.go
@@ -1,0 +1,124 @@
+package slice
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFold(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []any
+		acc      any
+		f        func(any, any) any
+		expected any
+	}{
+		{
+			name:     "sum",
+			data:     []any{1, 2, 3, 4, 5},
+			acc:      0,
+			f:        func(acc, e any) any { return acc.(int) + e.(int) },
+			expected: 15,
+		},
+		{
+			name:     "concat",
+			data:     []any{"a", "b", "c", "d", "e"},
+			acc:      "",
+			f:        func(acc, e any) any { return acc.(string) + e.(string) },
+			expected: "abcde",
+		},
+		{
+			name: "product",
+			data: []any{2, 3, 4, 5, 6},
+			acc:  1,
+			f: func(acc, e any) any {
+				return acc.(int) * e.(int)
+			},
+			expected: 720,
+		},
+		{
+			name:     "concat with acc",
+			data:     []any{"a", "b", "c", "d", "e"},
+			acc:      "result is: ",
+			f:        func(acc, e any) any { return acc.(string) + e.(string) },
+			expected: "result is: abcde",
+		},
+		{
+			name: "reverse",
+			data: []any{1, 2, 3, 4, 5},
+			acc:  []any{},
+			f:    func(acc, e any) any { return append([]any{e}, acc.([]any)...) },
+			expected: []any{
+				5, 4, 3, 2, 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := Fold(tt.acc, tt.data, tt.f)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("expected %d, got %d", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestFoldR(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []any
+		acc      any
+		f        func(any, any) any
+		expected any
+	}{
+		{
+			name:     "sum",
+			data:     []any{1, 2, 3, 4, 5},
+			acc:      0,
+			f:        func(acc, e any) any { return acc.(int) + e.(int) },
+			expected: 15,
+		},
+		{
+			name:     "concat",
+			data:     []any{"a", "b", "c", "d", "e"},
+			acc:      "",
+			f:        func(acc, e any) any { return acc.(string) + e.(string) },
+			expected: "edcba",
+		},
+		{
+			name: "product",
+			data: []any{2, 3, 4, 5, 6},
+			acc:  1,
+			f: func(acc, e any) any {
+				return acc.(int) * e.(int)
+			},
+			expected: 720,
+		},
+		{
+			name:     "concat with acc",
+			data:     []any{"a", "b", "c", "d", "e"},
+			acc:      "result is: ",
+			f:        func(acc, e any) any { return acc.(string) + e.(string) },
+			expected: "result is: edcba",
+		},
+		{
+			name: "reverse",
+			data: []any{1, 2, 3, 4, 5},
+			acc:  []any{},
+			f:    func(acc, e any) any { return append(acc.([]any), e) },
+			expected: []any{
+				5, 4, 3, 2, 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := FoldR(tt.acc, tt.data, tt.f)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("expected %d, got %d", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/slice/unfold.go
+++ b/pkg/slice/unfold.go
@@ -1,5 +1,10 @@
 package slice
 
+const (
+	DefaultMaxIterations = 100000
+	DefaultStep          = 1
+)
+
 type UnfoldConfig struct {
 	Max  int
 	Step int
@@ -9,10 +14,10 @@ type UnfoldOption func(*UnfoldConfig)
 
 // WithStep sets the step of the unfold.
 // This does not include the first step.
-// If max is 5, the length of the result is <= 6.
-func WithMax(max int) UnfoldOption {
+// If n is 5, the length of the result is <= 6.
+func WithMax(n int) UnfoldOption {
 	return func(c *UnfoldConfig) {
-		c.Max = max
+		c.Max = n
 	}
 }
 
@@ -31,8 +36,8 @@ func WithStep(step int) UnfoldOption {
 // It stops when the predicate returns false.
 func Unfold[T any](acc T, f func(T) T, p func(T) bool, opts ...UnfoldOption) []T {
 	config := &UnfoldConfig{
-		Max:  100000,
-		Step: 1,
+		Max:  DefaultMaxIterations,
+		Step: DefaultStep,
 	}
 
 	for _, opt := range opts {
@@ -60,8 +65,8 @@ func Unfold[T any](acc T, f func(T) T, p func(T) bool, opts ...UnfoldOption) []T
 // It stops after i iterations.
 func UnfoldI[T any](acc T, f func(T) T, n int, opts ...UnfoldOption) []T {
 	config := &UnfoldConfig{
-		Max:  100000,
-		Step: 1,
+		Max:  DefaultMaxIterations,
+		Step: DefaultStep,
 	}
 
 	for _, opt := range opts {

--- a/pkg/slice/unfold.go
+++ b/pkg/slice/unfold.go
@@ -1,13 +1,44 @@
 package slice
 
+type UnfoldConfig struct {
+	Max  int
+	Step int
+}
+
+type UnfoldOption func(*UnfoldConfig)
+
+// WithStep sets the step of the unfold.
+// This does not include the first step.
+// If max is 5, the length of the result is <= 6.
+func WithMax(max int) UnfoldOption {
+	return func(c *UnfoldConfig) {
+		c.Max = max
+	}
+}
+
 // Unfold generates a slice by repeatedly applying a function to an accumulator.
 // It includes the accumulator in the result as the first value.
 // If the predicate is always false, it returns nil.
 // It stops when the predicate returns false.
-func Unfold[T any](acc T, f func(T) T, p func(T) bool) []T {
+func Unfold[T any](acc T, f func(T) T, p func(T) bool, opts ...UnfoldOption) []T {
+	config := &UnfoldConfig{
+		Max:  100000,
+		Step: 1,
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	current := 0
 	var res []T
-	for a := acc; p(a); a = f(a) {
-		res = append(res, a)
+	for a := acc; p(a); a, current = f(a), current+1 {
+		if current%config.Step == 0 {
+			res = append(res, a)
+		}
+		if current >= config.Max {
+			return res
+		}
 	}
 
 	return res
@@ -15,16 +46,27 @@ func Unfold[T any](acc T, f func(T) T, p func(T) bool) []T {
 
 // UnfoldI generates a slice by repeatedly applying a function to an accumulator.
 // It includes the accumulator in the result as the first value.
-// The length of the result is equal to i.
+// The length of the result is equal to i + 1.
 // If i is negative, it returns nil.
 // It stops after i iterations.
-func UnfoldI[T any](acc T, f func(T) T, i int) []T {
-	if i < 0 {
+func UnfoldI[T any](acc T, f func(T) T, n int, opts ...UnfoldOption) []T {
+	config := &UnfoldConfig{
+		Max:  100000,
+		Step: 1,
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	if n < 0 {
 		return nil
 	}
 
-	res := make([]T, 0, i)
-	for range i {
+	n = min(n, config.Max)
+
+	res := make([]T, 0, n)
+	for i := 0; i <= n; i = i + config.Step {
 		res = append(res, acc)
 		acc = f(acc)
 	}

--- a/pkg/slice/unfold.go
+++ b/pkg/slice/unfold.go
@@ -16,6 +16,15 @@ func WithMax(max int) UnfoldOption {
 	}
 }
 
+// WithStep sets the step of the unfold.
+// This does not include the first step.
+// If step is 2, the result will include every second value.
+func WithStep(step int) UnfoldOption {
+	return func(c *UnfoldConfig) {
+		c.Step = step
+	}
+}
+
 // Unfold generates a slice by repeatedly applying a function to an accumulator.
 // It includes the accumulator in the result as the first value.
 // If the predicate is always false, it returns nil.
@@ -66,9 +75,15 @@ func UnfoldI[T any](acc T, f func(T) T, n int, opts ...UnfoldOption) []T {
 	n = min(n, config.Max)
 
 	res := make([]T, 0, n)
-	for i := 0; i <= n; i = i + config.Step {
-		res = append(res, acc)
+	res = append(res, acc)
+	for i := 1; i <= n; i++ {
 		acc = f(acc)
+		if i%config.Step == 0 {
+			res = append(res, acc)
+		}
+		if i >= config.Max {
+			return res
+		}
 	}
 
 	return res

--- a/pkg/slice/unfold.go
+++ b/pkg/slice/unfold.go
@@ -1,0 +1,33 @@
+package slice
+
+// Unfold generates a slice by repeatedly applying a function to an accumulator.
+// It includes the accumulator in the result as the first value.
+// If the predicate is always false, it returns nil.
+// It stops when the predicate returns false.
+func Unfold[T any](acc T, f func(T) T, p func(T) bool) []T {
+	var res []T
+	for a := acc; p(a); a = f(a) {
+		res = append(res, a)
+	}
+
+	return res
+}
+
+// UnfoldI generates a slice by repeatedly applying a function to an accumulator.
+// It includes the accumulator in the result as the first value.
+// The length of the result is equal to i.
+// If i is negative, it returns nil.
+// It stops after i iterations.
+func UnfoldI[T any](acc T, f func(T) T, i int) []T {
+	if i < 0 {
+		return nil
+	}
+
+	res := make([]T, 0, i)
+	for range i {
+		res = append(res, acc)
+		acc = f(acc)
+	}
+
+	return res
+}

--- a/pkg/slice/unfold_test.go
+++ b/pkg/slice/unfold_test.go
@@ -50,6 +50,14 @@ func TestUnfold(t *testing.T) {
 			p:        func(acc any) bool { return len(acc.(string)) < 5 },
 			expected: []any{"a", "aa", "aaa", "aaaa"},
 		},
+		{
+			name:     "with step",
+			acc:      1,
+			f:        func(acc any) any { return acc.(int) * 2 },
+			p:        func(acc any) bool { return acc.(int) < 100 },
+			opts:     []UnfoldOption{WithStep(2)},
+			expected: []any{1, 4, 16, 64},
+		},
 	}
 
 	for _, tt := range tests {
@@ -100,6 +108,16 @@ func TestUnfoldI(t *testing.T) {
 			opts: []UnfoldOption{WithMax(5)},
 			expected: []any{
 				1, 2, 4, 8, 16, 32,
+			},
+		},
+		{
+			name: "with step",
+			acc:  1,
+			f:    func(acc any) any { return acc.(int) * 2 },
+			i:    7,
+			opts: []UnfoldOption{WithStep(2)},
+			expected: []any{
+				1, 4, 16, 64,
 			},
 		},
 	}

--- a/pkg/slice/unfold_test.go
+++ b/pkg/slice/unfold_test.go
@@ -1,0 +1,77 @@
+package slice
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnfold(t *testing.T) {
+	tests := []struct {
+		name     string
+		acc      int
+		f        func(int) int
+		p        func(int) bool
+		expected []int
+	}{
+		{
+			name:     "double",
+			acc:      1,
+			f:        func(acc int) int { return acc * 2 },
+			p:        func(acc int) bool { return acc < 100 },
+			expected: []int{1, 2, 4, 8, 16, 32, 64},
+		},
+		{
+			name:     "always false p",
+			acc:      1,
+			f:        func(acc int) int { return acc * 2 },
+			p:        func(acc int) bool { return false },
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := Unfold(tt.acc, tt.f, tt.p)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("expected %v but got %v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUnfoldI(t *testing.T) {
+	tests := []struct {
+		name     string
+		acc      any
+		f        func(any) any
+		i        int
+		expected []any
+	}{
+		{
+			name:     "integers",
+			acc:      1,
+			f:        func(acc any) any { return acc.(int) * 2 },
+			i:        7,
+			expected: []any{1, 2, 4, 8, 16, 32, 64},
+		},
+		{
+			name:     "negative i",
+			acc:      1,
+			f:        func(acc any) any { return acc.(int) * 2 },
+			i:        -7,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := UnfoldI(tt.acc, tt.f, tt.i)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("expected %v but got %v", tt.expected, actual)
+			}
+			assert.Equal(t, max(tt.i, 0), len(actual))
+		})
+	}
+}


### PR DESCRIPTION
Added Fold (and FoldR) for reducing slices into single values. Useful for functions of similar nature as "sum" and "join", but more generally applicable. 

Added Unfold (and UnfoldI) for creating slices based on a seed, a generator, and either a predicate or element count. Useful for creating slices such as: 
`Unfold(1, func(acc int) int { return acc + 1 }, 10) == []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}`

Unfold (and UnfoldI) can set a limit of the maximum number of iterations to perform, using `WithMax(n)`.
Unfold (and UnfoldI) can set a step using `WithStep(n)`, indicating which iterations to add values for. I.e, using a step of 2, means every other value is added to the result.