### PR TITLE
feat: function for converting struct to map

### DIFF
--- a/pkg/structs/map.go
+++ b/pkg/structs/map.go
@@ -37,6 +37,10 @@ func handle(obj any) any {
 	}
 
 	val := reflect.ValueOf(obj)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
 	switch val.Kind() {
 	case reflect.Map:
 		return handleMap(obj)

--- a/pkg/structs/map.go
+++ b/pkg/structs/map.go
@@ -15,6 +15,7 @@ var tagCategories = []string{"json", "yaml"}
 // It handles nested structs, maps, and slices.
 // It uses the "json" and "yaml" tags to determine the key names.
 // It also respects the "omitempty" tag for fields.
+// It also respects the "inline" tag for nested structs.
 //
 // If the input is nil, it returns nil.
 // If the input is not a struct or map, it returns an error.
@@ -96,13 +97,14 @@ func handleStruct(obj any) any {
 			if _, ok := slice.FindFunc(tagOpts, func(s string) bool {
 				return s == "inline"
 			}); ok {
-				v := handle(value.Interface())
-				for k, v := range v.(map[string]any) {
-					if _, ok := res[k]; !ok {
-						res[k] = v
+				if nestedValues, ok := handle(value.Interface()).(map[string]any); ok {
+					for k, v := range nestedValues {
+						if _, ok := res[k]; !ok {
+							res[k] = v
+						}
 					}
+					continue
 				}
-				continue
 			}
 		}
 

--- a/pkg/structs/map.go
+++ b/pkg/structs/map.go
@@ -85,6 +85,27 @@ func handleStruct(obj any) any {
 			}
 		}
 
+		// Handle nested structs with inline tag
+		if value.Kind() == reflect.Ptr {
+			if value.IsNil() {
+				continue
+			}
+			value = value.Elem()
+		}
+		if value.Kind() == reflect.Struct {
+			if _, ok := slice.FindFunc(tagOpts, func(s string) bool {
+				return s == "inline"
+			}); ok {
+				v := handle(value.Interface())
+				for k, v := range v.(map[string]any) {
+					if _, ok := res[k]; !ok {
+						res[k] = v
+					}
+				}
+				continue
+			}
+		}
+
 		res[name] = handle(value.Interface())
 	}
 

--- a/pkg/structs/map.go
+++ b/pkg/structs/map.go
@@ -79,7 +79,7 @@ func handleStruct(obj any) any {
 			name = tagName
 		}
 
-		// Omit struct tag "-""
+		// Omit struct tag "-"
 		if _, ok := slice.FindFunc(tagOpts, func(s string) bool {
 			return s == "-"
 		}); ok || (name == "-" && len(tagOpts) == 0) {

--- a/pkg/structs/map.go
+++ b/pkg/structs/map.go
@@ -14,8 +14,9 @@ var tagCategories = []string{"json", "yaml"}
 // ToMap converts a struct or map to a map[string]any.
 // It handles nested structs, maps, and slices.
 // It uses the "json" and "yaml" tags to determine the key names.
-// It also respects the "omitempty" tag for fields.
-// It also respects the "inline" tag for nested structs.
+// It respects the "omitempty" tag for fields.
+// It respects the "inline" tag for nested structs.
+// It respects the "-" tag to omit fields.
 //
 // If the input is nil, it returns nil.
 // If the input is not a struct or map, it returns an error.
@@ -76,6 +77,13 @@ func handleStruct(obj any) any {
 		tagName, tagOpts := getTag(field)
 		if tagName != "" {
 			name = tagName
+		}
+
+		// Omit struct tag "-""
+		if _, ok := slice.FindFunc(tagOpts, func(s string) bool {
+			return s == "-"
+		}); ok || (name == "-" && len(tagOpts) == 0) {
+			continue
 		}
 
 		if _, ok := slice.FindFunc(tagOpts, func(s string) bool {

--- a/pkg/structs/map.go
+++ b/pkg/structs/map.go
@@ -1,0 +1,132 @@
+package structs
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/neticdk/go-common/pkg/slice"
+)
+
+// tagCategories is a list of tag categories to check for.
+var tagCategories = []string{"json", "yaml"}
+
+// ToMap converts a struct or map to a map[string]any.
+// It handles nested structs, maps, and slices.
+// It uses the "json" and "yaml" tags to determine the key names.
+// It also respects the "omitempty" tag for fields.
+//
+// If the input is nil, it returns nil.
+// If the input is not a struct or map, it returns an error.
+func ToMap(obj any) (map[string]any, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	res := handle(obj)
+	if v, ok := res.(map[string]any); ok {
+		return v, nil
+	}
+	return nil, fmt.Errorf("converting %T to map: not supported", obj)
+}
+
+// handle is a helper function that recursively handles
+// the conversion of structs, maps, and slices to a map[string]any.
+func handle(obj any) any {
+	if obj == nil {
+		return nil
+	}
+
+	val := reflect.ValueOf(obj)
+	switch val.Kind() {
+	case reflect.Map:
+		return handleMap(obj)
+	case reflect.Struct:
+		return handleStruct(obj)
+	case reflect.Slice:
+		return handleSlice(obj)
+	default:
+		return obj
+	}
+}
+
+// handleStruct handles the conversion of a struct to a map[string]any.
+// It uses the "json" and "yaml" tags to determine the key names.
+func handleStruct(obj any) any {
+	res := map[string]any{}
+	val := reflect.ValueOf(obj)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	for i := range val.NumField() {
+		field := val.Type().Field(i)
+
+		// Cannot get value from unexported field
+		if !field.IsExported() {
+			continue
+		}
+
+		name := field.Name
+		value := val.Field(i)
+		tagName, tagOpts := getTag(field)
+		if tagName != "" {
+			name = tagName
+		}
+
+		if _, ok := slice.FindFunc(tagOpts, func(s string) bool {
+			return s == "omitempty"
+		}); ok {
+			if reflect.DeepEqual(value.Interface(), reflect.Zero(val.Field(i).Type()).Interface()) {
+				continue
+			}
+		}
+
+		res[name] = handle(value.Interface())
+	}
+
+	return res
+}
+
+// handleMap handles the conversion of a map to a map[string]any,
+// recursively converting nested maps, slices and structs.
+func handleMap(obj any) any {
+	m := map[string]any{}
+	val := reflect.ValueOf(obj)
+	for _, key := range val.MapKeys() {
+		k := key.Interface()
+		v := val.MapIndex(key).Interface()
+		if k == nil {
+			continue
+		}
+		if v == nil {
+			continue
+		}
+		m[fmt.Sprintf("%v", k)] = handle(v)
+	}
+	return m
+}
+
+// handleSlice handles the conversion of a slice to a slice of any,
+// recursively converting nested maps, slices and structs.
+func handleSlice(obj any) any {
+	s := []any{}
+	val := reflect.ValueOf(obj)
+	for i := range val.Len() {
+		s = append(s, handle(val.Index(i).Interface()))
+	}
+	return s
+}
+
+// getTag retrieves the tag name and options from a struct field.
+// It checks for the "json" and "yaml" tags in that order.
+// If one tag is empty, it will return the other tag.
+// If both tags are empty, it returns an empty string and an empty slice.
+func getTag(field reflect.StructField) (string, []string) {
+	for _, category := range tagCategories {
+		if tag := field.Tag.Get(category); tag != "" {
+			splitTag := strings.Split(tag, ",")
+			return splitTag[0], splitTag[1:]
+		}
+	}
+	return "", []string{}
+}

--- a/pkg/structs/map_test.go
+++ b/pkg/structs/map_test.go
@@ -42,7 +42,7 @@ func TestToMap(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "simple struct",
+			name: "simple struct as pointer",
 			data: &struct {
 				A int    `json:"a"`
 				B string `json:"b"`
@@ -67,6 +67,30 @@ func TestToMap(t *testing.T) {
 					"d": 2,
 				},
 				"e": []any{"one", "two"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with inline",
+			data: &struct {
+				A int    `json:"a"`
+				B string `json:"b"`
+				C struct {
+					D int `json:"d"`
+				} `json:",inline"`
+			}{
+				A: 1,
+				B: "test",
+				C: struct {
+					D int `json:"d"`
+				}{
+					D: 2,
+				},
+			},
+			expected: map[string]any{
+				"a": 1,
+				"b": "test",
+				"d": 2,
 			},
 			wantErr: false,
 		},

--- a/pkg/structs/map_test.go
+++ b/pkg/structs/map_test.go
@@ -1,0 +1,137 @@
+package structs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestToMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     any
+		expected map[string]any
+		wantErr  bool
+	}{
+		{
+			name: "simple struct",
+			data: struct {
+				A int    `json:"a"`
+				B string `json:"b"`
+				C struct {
+					D int `json:"d"`
+				} `json:"c"`
+				E []string `json:"e,omitempty"`
+			}{
+				A: 1,
+				B: "test",
+				C: struct {
+					D int `json:"d"`
+				}{
+					D: 2,
+				},
+				E: []string{"one", "two"},
+			},
+			expected: map[string]any{
+				"a": 1,
+				"b": "test",
+				"c": map[string]any{
+					"d": 2,
+				},
+				"e": []any{"one", "two"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nested struct",
+			data: struct {
+				A struct {
+					B struct {
+						C int `json:"c"`
+					} `json:"b"`
+				} `json:"a"`
+			}{
+				A: struct {
+					B struct {
+						C int `json:"c"`
+					} `json:"b"`
+				}{
+					B: struct {
+						C int `json:"c"`
+					}{
+						C: 3,
+					},
+				},
+			},
+			expected: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": 3,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "map with string keys",
+			data: map[string]any{
+				"a": 1,
+				"b": "test",
+				"c": map[string]any{
+					"d": 2,
+				},
+				"e": []string{"one", "two"},
+				"f": struct {
+					G int `json:"g"`
+				}{
+					G: 4,
+				},
+			},
+			expected: map[string]any{
+				"a": 1,
+				"b": "test",
+				"c": map[string]any{
+					"d": 2,
+				},
+				"e": []any{"one", "two"},
+				"f": map[string]any{
+					"g": 4,
+				},
+			},
+		},
+		{
+			name: "slice",
+			data: []any{
+				1,
+				"test",
+			},
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "scalar",
+			data:     42,
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "nil",
+			data:     nil,
+			expected: nil,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToMap(tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ToMap() got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+
+}

--- a/pkg/structs/map_test.go
+++ b/pkg/structs/map_test.go
@@ -95,6 +95,54 @@ func TestToMap(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "with omit '-'",
+			data: &struct {
+				A int    `json:"a"`
+				B string `json:",-"`
+				C struct {
+					D int `json:"d"`
+				} `json:"-"`
+			}{
+				A: 1,
+				B: "test",
+				C: struct {
+					D int `json:"d"`
+				}{
+					D: 2,
+				},
+			},
+			expected: map[string]any{
+				"a": 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "with omit '-' as name",
+			data: &struct {
+				A int    `json:"a"`
+				B string `json:"b"`
+				C struct {
+					D int `json:"d"`
+				} `json:"-,"`
+			}{
+				A: 1,
+				B: "test",
+				C: struct {
+					D int `json:"d"`
+				}{
+					D: 2,
+				},
+			},
+			expected: map[string]any{
+				"a": 1,
+				"b": "test",
+				"-": map[string]any{
+					"d": 2,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "nested struct",
 			data: struct {
 				A struct {

--- a/pkg/structs/map_test.go
+++ b/pkg/structs/map_test.go
@@ -42,6 +42,35 @@ func TestToMap(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "simple struct",
+			data: &struct {
+				A int    `json:"a"`
+				B string `json:"b"`
+				C struct {
+					D int `json:"d"`
+				} `json:"c"`
+				E []string `json:"e,omitempty"`
+			}{
+				A: 1,
+				B: "test",
+				C: struct {
+					D int `json:"d"`
+				}{
+					D: 2,
+				},
+				E: []string{"one", "two"},
+			},
+			expected: map[string]any{
+				"a": 1,
+				"b": "test",
+				"c": map[string]any{
+					"d": 2,
+				},
+				"e": []any{"one", "two"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "nested struct",
 			data: struct {
 				A struct {


### PR DESCRIPTION
Using reflect to convert a struct (or map), recursively converting any seen nested structs to maps. 
Uses `json` or `yaml` tags for names if present, currently supporting `omitempty` as well.
