### PR TITLE
fix(repometrics): update Scanner interface to use CDX format

### DIFF
--- a/pkg/repometrics/vulnerabilities.go
+++ b/pkg/repometrics/vulnerabilities.go
@@ -10,18 +10,16 @@ import (
 // Scanner is the interface for vulnerability scanners
 type Scanner interface {
 	// Scan scans for vulnerabilities
-	Scan(context.Context) ([]types.Vulnerability, error)
+	Scan(context.Context) ([]types.VulnerabilityCDX, error)
 }
 
 // ScanVulnerabilities scans for vulnerabilities and updates the metrics
 func (m *Metrics) ScanVulnerabilities(ctx context.Context, s Scanner) error {
-	var err error
 	vulnerabilities, err := s.Scan(ctx)
 	if err != nil {
 		return fmt.Errorf("scanning vulnerabilities: %w", err)
 	}
-	// m.Vulnerabilities = vulnerabilities //TODO: we need to produce a cycloneDX file from scanning, //nolint:gofumpt
-	// TODO: have that file being picked up in same way as externally generated setups using SBOM, Vulnerability files and VEX //nolint:gofumpt
-	str := "TODO: Produce Vulnerabilities should be produced in CycloneDX format for the d% vulnerabilities found"
-	return fmt.Errorf(str, len(vulnerabilities))
+
+	m.Vulnerabilities = vulnerabilities
+	return nil
 }


### PR DESCRIPTION
Since this interface is meant for consumers (i.e. Beagle), simply change the interface to fit new `VulnerabilityCDX` format.

This change is breaking for consumers of the `repometrics.Scanner` interface. However, since the previous implementation of `repometrics.Metrics.ScanVulnerabilities` which consumes the interface always emitted an error, this likely was broken anyway. 