### PR TITLE
feat: add SetupFlags function to subcommands

### DIFF
--- a/pkg/cli/TUTORIAL.md
+++ b/pkg/cli/TUTORIAL.md
@@ -937,15 +937,12 @@ func newDriveCmd(ac *myapp.Context) *cobra.Command {
         WithGroupID(groupComponent).
         Build()
 
-    o.bindFlags(c.Flags())
-    c.Flags().SortFlags = false
-    _ = c.MarkFlagRequired("name")
-    _ = c.MarkFlagRequired("age")
     return c
 }
 ```
 
-Notice the `bindFlags` function. It binds the command line flags to the options.
+Flags are bound in to the options struct using the `SetupFlags` method.
+
 You will have to create it yourself.
 
 Let's see an example of how to do that:
@@ -953,9 +950,16 @@ Let's see an example of how to do that:
 ```go
 import "github.com/spf13/pflag"
 
-func (o *driveOptions) bindFlags(f *pflag.FlagSet) {
-    f.StringVar(&o.name, "name", "", "Driver name")
-    f.IntVar(&o.age, "age", 0, "Driver age")
+func (o *driveOptions) SetupFlags(_ context.Context, cmd *cobra.Command) error {
+    flags := cmd.Flags()
+    flags.SortFlags = false
+    _ = cmd.MarkFlagRequired("name")
+    _ = cmd.MarkFlagRequired("age")
+
+    flags.StringVar(&o.name, "name", "", "Driver name")
+    flags.IntVar(&o.age, "age", 0, "Driver age")
+
+    return nil
 }
 ```
 

--- a/pkg/cli/TUTORIAL.md
+++ b/pkg/cli/TUTORIAL.md
@@ -950,14 +950,22 @@ Let's see an example of how to do that:
 ```go
 import "github.com/spf13/pflag"
 
-func (o *driveOptions) SetupFlags(_ context.Context, cmd *cobra.Command) error {
+func (o *driveOptions) SetupFlags(_ context.Context, ac *helloworld.Context) error {
+    cmd := ac.EC.Command
     flags := cmd.Flags()
-    flags.SortFlags = false
-    _ = cmd.MarkFlagRequired("name")
-    _ = cmd.MarkFlagRequired("age")
 
     flags.StringVar(&o.name, "name", "", "Driver name")
     flags.IntVar(&o.age, "age", 0, "Driver age")
+
+    flags.SortFlags = false
+
+    if err := cmd.MarkFlagRequired("name"); err != nil {
+        return err
+    }
+    if err := cmd.MarkFlagRequired("age"); err != nil {
+        return err
+    }
+
 
     return nil
 }

--- a/pkg/cli/cmd/gendocs.go
+++ b/pkg/cli/cmd/gendocs.go
@@ -15,9 +15,9 @@ type genDocsOptions struct {
 	dir string
 }
 
-func (o *genDocsOptions) SetupFlags(_ context.Context, _ *cobra.Command) error  { return nil }
-func (o *genDocsOptions) Complete(_ context.Context, _ *ExecutionContext) error { return nil }
-func (o *genDocsOptions) Validate(_ context.Context, _ *ExecutionContext) error { return nil }
+func (o *genDocsOptions) SetupFlags(_ context.Context, _ *ExecutionContext) error { return nil }
+func (o *genDocsOptions) Complete(_ context.Context, _ *ExecutionContext) error   { return nil }
+func (o *genDocsOptions) Validate(_ context.Context, _ *ExecutionContext) error   { return nil }
 func (o *genDocsOptions) Run(_ context.Context, ec *ExecutionContext) error {
 	if err := os.MkdirAll(o.dir, file.FileModeNewDirectory); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", o.dir, err)

--- a/pkg/cli/cmd/gendocs.go
+++ b/pkg/cli/cmd/gendocs.go
@@ -15,6 +15,7 @@ type genDocsOptions struct {
 	dir string
 }
 
+func (o *genDocsOptions) SetupFlags(_ context.Context, _ *cobra.Command) error  { return nil }
 func (o *genDocsOptions) Complete(_ context.Context, _ *ExecutionContext) error { return nil }
 func (o *genDocsOptions) Validate(_ context.Context, _ *ExecutionContext) error { return nil }
 func (o *genDocsOptions) Run(_ context.Context, ec *ExecutionContext) error {

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -67,6 +67,11 @@ func NewRootCommand(ec *ExecutionContext) *RootCommandBuilder {
 		},
 	}
 
+	// Update default execution context command
+	// For subcommands, this is set to the subcommand's command though
+	// PersistentPreRunE (defaultInitFunc)
+	ec.Command = c
+
 	AddPersistentFlags(c, ec)
 	ec.SetLogLevel()
 

--- a/pkg/cli/cmd/subcommand.go
+++ b/pkg/cli/cmd/subcommand.go
@@ -53,6 +53,9 @@ func NewSubCommand[T any](
 // Build builds the subcommand
 func (b *SubCommandBuilder[T]) Build() *cobra.Command {
 	b.cmd.RunE = mkRunE(b.runner, b.runnerArg)
+	if err := b.runner.SetupFlags(b.cmd.Context(), b.cmd); err != nil {
+		panic(err)
+	}
 	return b.cmd
 }
 
@@ -155,9 +158,6 @@ func (b *SubCommandBuilder[T]) WithMaxArgs(n int) *SubCommandBuilder[T] {
 func mkRunE[T any](runner SubCommandRunner[T], runnerArg T) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
 		ctx := cmd.Context()
-		if err := runner.SetupFlags(ctx, cmd); err != nil {
-			return err
-		}
 		if err := runner.Complete(ctx, runnerArg); err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/subcommand_test.go
+++ b/pkg/cli/cmd/subcommand_test.go
@@ -87,6 +87,28 @@ func Test_mkRunE(t *testing.T) {
 	})
 }
 
+type testOpts struct {
+	testFlag string
+}
+
+func (o *testOpts) SetupFlags(_ context.Context, cmd *cobra.Command) error {
+	flags := cmd.Flags()
+	flags.StringVar(&o.testFlag, "test-flag", "default-value", "Test flag")
+	return nil
+}
+func (o *testOpts) Complete(_ context.Context, _ any) error { return nil }
+func (o *testOpts) Validate(_ context.Context, _ any) error { return nil }
+func (o *testOpts) Run(_ context.Context, _ any) error      { return nil }
+
+func TestSetupFlags(t *testing.T) {
+	o := &testOpts{}
+	builder := NewSubCommand("test", o, nil)
+	cmd := builder.Build()
+	v, err := cmd.Flags().GetString("test-flag")
+	assert.Nil(t, err)
+	assert.Equal(t, "default-value", v)
+}
+
 func TestArgsHelpers(t *testing.T) {
 	t.Run("NoArgsReturnsErrorWhenArgsProvided", func(t *testing.T) {
 		builder := NewSubCommand("test", &NoopRunner[any]{}, nil)

--- a/pkg/cli/cmd/subcommand_test.go
+++ b/pkg/cli/cmd/subcommand_test.go
@@ -42,6 +42,7 @@ func Test_mkRunE(t *testing.T) {
 	t.Run("complete_called", func(t *testing.T) {
 		completeCalled := false
 		runner := &TestRunner[arg]{
+			SetupFlagsFunc: func(ctx context.Context, cmd *cobra.Command) error { return nil },
 			CompleteFunc: func(ctx context.Context, a arg) error {
 				completeCalled = true
 				return nil
@@ -58,9 +59,10 @@ func Test_mkRunE(t *testing.T) {
 
 	t.Run("validate_error", func(t *testing.T) {
 		runner := &TestRunner[arg]{
-			CompleteFunc: func(ctx context.Context, a arg) error { return nil },
-			ValidateFunc: func(ctx context.Context, a arg) error { return assert.AnError },
-			RunFunc:      func(ctx context.Context, a arg) error { return nil },
+			SetupFlagsFunc: func(ctx context.Context, cmd *cobra.Command) error { return nil },
+			CompleteFunc:   func(ctx context.Context, a arg) error { return nil },
+			ValidateFunc:   func(ctx context.Context, a arg) error { return assert.AnError },
+			RunFunc:        func(ctx context.Context, a arg) error { return nil },
 		}
 		runE := mkRunE(runner, arg{})
 		cmd := &cobra.Command{}
@@ -71,9 +73,10 @@ func Test_mkRunE(t *testing.T) {
 	t.Run("run_called", func(t *testing.T) {
 		runCalled := false
 		runner := &TestRunner[arg]{
-			CompleteFunc: func(ctx context.Context, a arg) error { return nil },
-			ValidateFunc: func(ctx context.Context, a arg) error { return nil },
-			RunFunc:      func(ctx context.Context, a arg) error { runCalled = true; return nil },
+			SetupFlagsFunc: func(ctx context.Context, cmd *cobra.Command) error { return nil },
+			CompleteFunc:   func(ctx context.Context, a arg) error { return nil },
+			ValidateFunc:   func(ctx context.Context, a arg) error { return nil },
+			RunFunc:        func(ctx context.Context, a arg) error { runCalled = true; return nil },
 		}
 
 		runE := mkRunE(runner, arg{})

--- a/pkg/cli/examples/pokemon/cmd/root.go
+++ b/pkg/cli/examples/pokemon/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"pokemon/internal/pokemon"
 
 	"github.com/neticdk/go-common/pkg/cli/cmd"
@@ -38,10 +36,7 @@ func Execute(version string) int {
 	ec := cmd.NewExecutionContext(
 		AppName,
 		ShortDesc,
-		version,
-		os.Stdin,
-		os.Stdout,
-		os.Stderr)
+		version)
 	ac := pokemon.NewContext()
 	ac.EC = ec
 	ec.LongDescription = LongDesc

--- a/pkg/cli/examples/pokemon/cmd/search_pokemon.go
+++ b/pkg/cli/examples/pokemon/cmd/search_pokemon.go
@@ -12,7 +12,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/cmd"
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newSearchPokemonCmd(ac *pokemon.Context) *cobra.Command {
@@ -23,7 +22,6 @@ func newSearchPokemonCmd(ac *pokemon.Context) *cobra.Command {
 		WithExample(searchPokemonCmdExample()).
 		Build()
 
-	o.bindFlags(c.Flags())
 	return c
 }
 
@@ -31,8 +29,10 @@ type searchPokemonOptions struct {
 	name string
 }
 
-func (o *searchPokemonOptions) bindFlags(f *pflag.FlagSet) {
-	f.StringVar(&o.name, "name", "", "Name of the pokemon to search for")
+func (o *searchPokemonOptions) SetupFlags(_ context.Context, cmd *cobra.Command) error {
+	flags := cmd.Flags()
+	flags.StringVar(&o.name, "name", "", "Name of the pokemon to search for")
+	return nil
 }
 
 func (o *searchPokemonOptions) Complete(_ context.Context, ac *pokemon.Context) error {

--- a/pkg/cli/examples/pokemon/go.mod
+++ b/pkg/cli/examples/pokemon/go.mod
@@ -1,7 +1,71 @@
 module pokemon
 
-go 1.24.1
+go 1.24.2
 
-require github.com/neticdk/go-common v0.0.0
+toolchain go1.24.3
+
+require (
+	github.com/mtslzr/pokeapi-go v1.4.0
+	github.com/neticdk/go-common v0.0.0
+	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	atomicgo.dev/cursor v0.2.0 // indirect
+	atomicgo.dev/keyboard v0.2.9 // indirect
+	atomicgo.dev/schedule v0.1.0 // indirect
+	github.com/alecthomas/chroma/v2 v2.15.0 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/charmbracelet/colorprofile v0.3.0 // indirect
+	github.com/charmbracelet/glamour v0.10.0 // indirect
+	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
+	github.com/charmbracelet/x/ansi v0.8.0 // indirect
+	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
+	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
+	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/containerd/console v1.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/gookit/color v1.5.4 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/lithammer/fuzzysearch v1.1.8 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/neticdk/go-stdlib v0.2.1 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pterm/pterm v0.12.80 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sagikazarmark/locafero v0.9.0 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.14.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
+	github.com/spf13/viper v1.20.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/goldmark v1.7.8 // indirect
+	github.com/yuin/goldmark-emoji v1.0.5 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/term v0.32.0 // indirect
+	golang.org/x/text v0.25.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 replace github.com/neticdk/go-common => ../../../..


### PR DESCRIPTION
Adds `SetupFlags` to the `SubCommandRunner` interface as a conventional, unified and less ambiguous way to configure flags than the current way where some things are handled in the `bindFlags` function and other things in the constructor.

Fixes #126 