### PR TITLE
feat: Allow for pure env-var config of OTLP

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -35,7 +35,7 @@ func WithoutMetricsServer() Option {
 	}
 }
 
-// WithEnvConfig disables default options to OTLP trace client and allows for env params
+// WithEnvConfig allows for OTLP trace client configuration via environment variables, overriding the default insecure gRPC connection.
 func WithEnvConfig() Option {
 	return func(c *config) {
 		c.envConfig = true


### PR DESCRIPTION
Make it possible to disable default configuration to allow for using the standard OTLP environment configuration notably `OTEL_EXPORTER_OTLP_ENDPOINT`